### PR TITLE
build/Dockerfile.operator.openshift: fix COPY path

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -5,7 +5,7 @@ RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/kubernetes-nmstate
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-COPY --from=builder /go/src/github.com/nmstate/kubernetes-nmstate/build/_output/bin/kubernetes-nmstate  /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/kubernetes-nmstate  /usr/bin/
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/
 COPY deploy/handler/namespace.yaml /bindata/kubernetes-nmstate/namespace/
 COPY deploy/handler/operator.yaml /bindata/kubernetes-nmstate/handler/handler.yaml


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
The downstream build that uses this file would fail because the path the binary was built in the first stage does not match the path the second stage tried to copy it from.

**Release note**:
n/a

I accidentally created an upstream PR first: https://github.com/nmstate/kubernetes-nmstate/pull/588
... but perhaps you'd prefer to pursue it there.