### PR TITLE
Remove duplicated 'certified' key in CSV

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -23,7 +23,6 @@ metadata:
     olm.skipRange: ">=4.3.0-0 < 4.7.0-0"
     support: Red Hat, Inc.
     repository: https://github.com/openshift/kubernetes-nmstate
-    certified: "false"
   name: kubernetes-nmstate-operator.v4.7.0
   namespace: openshift-nmstate
 spec:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Removes duplicated `certified` key in CSV, ([line #17](https://github.com/openshift/kubernetes-nmstate/blob/afa9c598cb418ec3f04929f635940bd29e1ea740/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml#L17) and [line #26](https://github.com/openshift/kubernetes-nmstate/blob/afa9c598cb418ec3f04929f635940bd29e1ea740/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml#L26)) which is currently causing the following error when building the bundle:
```
Image build failed. Error in plugin pin_operator_digest: while
constructing a mapping\n  in
"/tmp/tmpii4h0l34/openshift-kubernetes-nmstate-operator-bundle/manifests/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml",
line 5, column 5\nfound duplicate key "certified" with value "false"
(original value: "false")\n  in
"/tmp/tmpii4h0l34/openshift-kubernetes-nmstate-operator-bundle/manifests/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml",
line 26, column 5\n\nTo suppress this check see:\n
http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys\n\nDuplicate
keys will become and error in future releases, and are errors\nby
default when using the new API.\n. OSBS build id:
openshift-kubernetes-nmstate-op-rhaos-47-rhel-8-2faf9-1
```

**Release note**:
```release-note
NONE
```
