### PR TITLE
[CARRY] Add cluster rules for nmstate-handler sa

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -97,6 +97,16 @@ spec:
           resourceNames:
           - privileged
         serviceAccountName: nmstate-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+        serviceAccountName: nmstate-handler
       deployments:
       - name: nmstate-operator
         spec:


### PR DESCRIPTION
This adds the privileged SCC for the nmstate-handler serviceaccount.
The nmstate-operator serviceaccount was not enough.
Multiple sa's can be specificed in the CSV.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
