### PR TITLE
[CARRY] Move the nmstate-handler sa to the correct section

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -97,16 +97,6 @@ spec:
           resourceNames:
           - privileged
         serviceAccountName: nmstate-operator
-      - rules:
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - use
-          resourceNames:
-          - privileged
-        serviceAccountName: nmstate-handler
       deployments:
       - name: nmstate-operator
         spec:
@@ -185,6 +175,16 @@ spec:
           verbs:
           - '*'
         serviceAccountName: nmstate-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+        serviceAccountName: nmstate-handler
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
Originally I placed the nmstate-handler SA under the cluster
permission. It needed to be in the namespaced section.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
