### PR TITLE
Bug 1918958: Fix the example NMState instance in the manifest

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -10,7 +10,9 @@ metadata:
           "name": "nmstate"
         },
         "spec": {
-          "nodeSelector": "beta.kubernetes.io/arch=amd64"
+          "nodeSelector": {
+            "beta.kubernetes.io/arch": "amd64"
+          }
         }
       }]
     capabilities: Basic Install


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
It fixes the example in the manifest. This has the side affect that one would not have to modify the spec in yaml mode when creating an instance of Kind: NMState.
**Special notes for your reviewer**:
As long as you don't have to click over to yaml mode and either fix the yaml, or remove the nodeSelector, it is working as it should.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
