### PR TITLE
Bug 1960446: UPSTREAM: <carry>: Change handler toleration to "operator: exists" (#…

### DIFF
--- a/controllers/nmstate_controller.go
+++ b/controllers/nmstate_controller.go
@@ -154,6 +154,10 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 		Operator: corev1.TolerationOpExists,
 		Effect:   corev1.TaintEffectNoSchedule,
 	}
+	operatorExistsToleration := corev1.Toleration{
+		Key:      "",
+		Operator: corev1.TolerationOpExists,
+	}
 	amd64ArchOnMasterNodeSelector := map[string]string{
 		"beta.kubernetes.io/arch":        "amd64",
 		"node-role.kubernetes.io/master": "",
@@ -172,7 +176,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1beta1.NMState) error
 	data.Data["WebhookTolerations"] = []corev1.Toleration{masterExistsNoScheduleToleration}
 	data.Data["WebhookAffinity"] = corev1.Affinity{}
 	data.Data["HandlerNodeSelector"] = amd64AndCRNodeSelector
-	data.Data["HandlerTolerations"] = []corev1.Toleration{masterExistsNoScheduleToleration}
+	data.Data["HandlerTolerations"] = []corev1.Toleration{operatorExistsToleration}
 	data.Data["HandlerAffinity"] = corev1.Affinity{}
 	// TODO: This is just a place holder to make template renderer happy
 	//       proper variable has to be read from env or CR


### PR DESCRIPTION
…755)

Since nmstate is to be used for configuration of the network
infrastructure, we want the handler to run on all nodes regardless
of taint. If a network config should not run on a given node, the
NNCP nodeSelector field can be used to accomplish that.

For example, a node with a taint of:

[map[effect:NoSchedule key:node.ocs.openshift.io/storage value:true]]

will currently keep the nmstate handler pod from running there.
However, that is not desirable since it prevents the use of nmstate
to configure networking on that storage node.

This changes the handler toleration to "operator: exists", which
will allow the handler to run on all nodes. The webhook toleration
is left alone since there is no need for that to be running on
nodes with a NoSchedule taint.

Signed-off-by: Ben Nemec <bnemec@redhat.com>
(cherry picked from commit b2bccf90bfe0ce03a0090c9d9e45af17276d5021)

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the master branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
