### PR TITLE
Bug 1987136: Declare supported arches in CSV

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -25,6 +25,8 @@ metadata:
     olm.skipRange: ">=4.3.0-0 < 4.7.0-0"
     support: Red Hat, Inc.
     repository: https://github.com/openshift/kubernetes-nmstate
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: kubernetes-nmstate-operator.v4.7.0
   namespace: openshift-nmstate
 spec:

--- a/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
@@ -25,6 +25,8 @@ metadata:
     olm.skipRange: ">=4.3.0-0 < 4.7.0-0"
     support: Red Hat, Inc.
     repository: https://github.com/openshift/kubernetes-nmstate
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: kubernetes-nmstate-operator.v4.8.0
   namespace: openshift-nmstate
 spec:

--- a/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
@@ -25,6 +25,8 @@ metadata:
     olm.skipRange: ">=4.3.0-0 < 4.7.0-0"
     support: Red Hat, Inc.
     repository: https://github.com/openshift/kubernetes-nmstate
+  labels:
+    operatorframework.io/arch.amd64: supported
   name: kubernetes-nmstate-operator.v4.9.0
   namespace: openshift-nmstate
 spec:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:

﻿The OperatorHub currently assumes x86-only for any operators which do
not declare any such labels.  Declaring these explicitly should make the
current status more obvious in the code, and make it easier to correctly
add further architectures when conditions warrant.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
