### PR TITLE
Remove Brad and Toni from reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,12 +9,10 @@ approvers:
 reviewers:
   - phoracek
   - qinqon
-  - bcrochet
   - yboaron
   - RamLavi
   - rhrazdil
   - cybertron
-  - celebdor
 
 # Bugzilla info;
 component: Networking


### PR DESCRIPTION
They're now focused on other things so we don't want them auto-assigned to PRs in this repo.
