### PR TITLE
UPSTREAM: <carry>: Provide default NMState CR

### DIFF
--- a/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
@@ -2,6 +2,20 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    operatorframework.io/initialization-resource: |-
+      [{
+        "apiVersion": "nmstate.io/v1beta1",
+        "kind": "NMState",
+        "metadata": {
+          "name": "nmstate",
+          "namespace":"openshift-nmstate"
+        },
+        "spec": {
+          "nodeSelector": {
+            "beta.kubernetes.io/arch": "amd64"
+          }
+        }
+      }]
     alm-examples: |-
       [{
         "apiVersion": "nmstate.io/v1beta1",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, admins have to install the NMState in two steps.  First they
have to install the operator and then navigate to the operator menu to
create an NMState CR.

With this patch, these two are merged into a single step where while
installing NMState operator, user will be asked to create the CR since
it is required. That then immediatelly triggers deployment of NMState
operands as a part of the NMState operator installation.

This is how it looks on CNV:

![nmstate-cr](https://user-images.githubusercontent.com/3493830/134359687-25e40aca-22c7-40c1-8601-9c10e41de262.png)

![nmstate-cr](https://user-images.githubusercontent.com/3493830/134360092-e2cd6e80-d961-444d-abee-80e0fcbfef4f.png)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
