### PR TITLE
Add OCP specific e2e test infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,9 @@ test-e2e-operator: manifests $(GINKGO)
 
 test-e2e: test-e2e-operator test-e2e-handler
 
+test-e2e-ocp: 
+	./hack/ocp-e2e-tests.sh
+
 cluster-up:
 	./cluster/up.sh
 
@@ -263,4 +266,5 @@ olm-push: bundle-push index-push
 	generate-manifests \
 	tools \
 	bundle \
-	bundle-build
+	bundle-build \
+	manifests

--- a/hack/ocp-e2e-tests.sh
+++ b/hack/ocp-e2e-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Make sure to set the IMAGE_REPO env variable to your quay.io username
+# before running this script.
+
+# Additionally, the e2e tests rely on extra nics being configured on the
+# node. If running from dev-scripts, it will be necessary to configure it to
+# deploy the extra nics.
+# See https://github.com/openshift-metal3/dev-scripts/pull/1286 for an example.
+
+set -ex
+
+export KUBEVIRT_PROVIDER=external
+export IMAGE_BUILDER=podman
+export DEV_IMAGE_REGISTRY=quay.io
+export KUBEVIRTCI_RUNTIME=podman
+export SSH=./hack/ssh.sh
+export PRIMARY_NIC=enp2s0
+export FIRST_SECONDARY_NIC=enp3s0
+export SECOND_SECONDARY_NIC=enp4s0
+
+make cluster-sync-operator
+# Will fail on subsequent runs, this is fine.
+oc create -f build/_output/manifests/scc.yaml || :
+oc create -f test/e2e/nmstate.yaml
+# On first deployment, it can take a while for all of the pods to come up
+# First wait for the handler pods to be created
+while ! oc get pods -n nmstate | grep handler; do sleep 1; done
+# Then wait for them to be ready
+while oc get pods -n nmstate | grep "0/1"; do sleep 1; done
+# NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
+make test-e2e-handler E2E_TEST_ARGS="--skip=user-guide --skip=bridged" E2E_TEST_TIMEOUT=120m

--- a/hack/ssh.sh
+++ b/hack/ssh.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+node_name=${1}
+node_ip=$(oc get node ${node_name} --no-headers -o wide | awk '{print $6}')
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@${node_ip} -- ${@:3}

--- a/test/e2e/machineconfigs.yaml
+++ b/test/e2e/machineconfigs.yaml
@@ -1,0 +1,52 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 10-nmstate-hack-master
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=NMState e2e hack
+          Wants=crio.service
+          Before=kubelet.service
+          After=crio.service
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/bash -c "for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; done"
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: nmstate-hack.service
+
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 10-nmstate-hack-worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=NMState e2e hack
+          Wants=crio.service
+          Before=kubelet.service
+          After=crio.service
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/bash -c "for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; done"
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: nmstate-hack.service

--- a/test/e2e/nmstate.yaml
+++ b/test/e2e/nmstate.yaml
@@ -1,0 +1,4 @@
+apiVersion: nmstate.io/v1beta1
+kind: NMState
+metadata:
+  name: nmstate


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
Adds the ability to run e2e tests on OCP:
* Creates some machine configs required for e2e tests on OCP
* Adds a make target to run the tests (`test-e2e-ocp`)
* Allows to run the e2e tests against clusters with OVN (sets `PRIMARY_NIC=enp1s0` in this case)

**Special notes for your reviewer**:
* This PR is based on #198 from @cybertron. 
* As adding the machine configs for persistent-networking will be added in MCO in future, this is made as a separate commit to revert
* The env vars `IMAGE_REPO` and `KUBECONFIG` must be set anyhow, e.g.: `IMAGE_REPO=creydr KUBECONFIG=~/development/dev-scripts/ocp/ostest/auth/kubeconfig make test-e2e-ocp`

**Release note**:
```release-note
NONE
```
