### PR TITLE
Add OLM manifests for OCP 4.10 release

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes-nmstate
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/operator
 
-FROM registry.ci.openshift.org/ocp/4.9:base
+FROM registry.ci.openshift.org/ocp/4.10:base
 
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/manager /usr/bin/
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/

--- a/manifests/4.10/image-references
+++ b/manifests/4.10/image-references
@@ -1,0 +1,12 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: kubernetes-nmstate-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kubernetes-nmstate-operator:4.10
+  - name: kubernetes-nmstate-handler
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kubernetes-nmstate-handler:4.10

--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -1,0 +1,233 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "nmstate.io/v1",
+        "kind": "NMState",
+        "metadata": {
+          "name": "nmstate"
+        },
+        "spec": {
+          "nodeSelector": {
+            "beta.kubernetes.io/arch": "amd64"
+          }
+        }
+      }
+    alm-examples: |-
+      [{
+        "apiVersion": "nmstate.io/v1",
+        "kind": "NMState",
+        "metadata": {
+          "name": "nmstate"
+        },
+        "spec": {
+          "nodeSelector": {
+            "beta.kubernetes.io/arch": "amd64"
+          }
+        }
+      }]
+    operatorframework.io/suggested-namespace: openshift-nmstate
+    capabilities: Basic Install
+    certified: "false"
+    categories: OpenShift Optional
+    description: |
+      Kubernetes NMState is a declaritive means of configuring NetworkManager.
+    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.10
+    createdAt: "2021-10-26 10:52:26"
+    olm.skipRange: ">=4.3.0 <4.10.0"
+    support: Red Hat, Inc.
+    repository: https://github.com/openshift/kubernetes-nmstate
+  labels:
+    operatorframework.io/arch.amd64: supported
+  name: kubernetes-nmstate-operator.v4.10.0
+  namespace: openshift-nmstate
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: NMState
+      name: nmstates.nmstate.io
+      version: v1
+      description: Represents an NMState deployment.
+      displayName: NMState
+  description: A Kubernetes Operator to install Kubernetes NMState
+  displayName: Kubernetes NMState Operator
+  icon:
+    - base64data: >-
+        PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNzkuNDcgMTMzLjg4Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6IzFkNTZkODt9LmNscy0ye2ZpbGw6IzcwYWRlZjt9PC9zdHlsZT48L2RlZnM+PGcgaWQ9IkxheWVyXzIiIGRhdGEtbmFtZT0iTGF5ZXIgMiI+PGcgaWQ9IkxheWVyXzEtMiIgZGF0YS1uYW1lPSJMYXllciAxIj48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xNy41MSwxMTMuNjhhNi41LDYuNSwwLDAsMC00LjMtMS4zMywxMS43LDExLjcsMCwwLDAtMy42MS41MUExMy42NywxMy42NywwLDAsMCw2LjksMTE0djE5YTUuMTgsNS4xOCwwLDAsMS0uNzYuMjMsNC40MSw0LjQxLDAsMCwxLTEuMTIuMTNxLTIuMTksMC0yLjE5LTEuODNWMTE0LjI0YTMuMjMsMy4yMywwLDAsMSwuNDMtMS43Niw0LjU5LDQuNTksMCwwLDEsMS41LTEuMzUsMTUuMTgsMTUuMTgsMCwwLDEsMy41MS0xLjQ3LDE3LjExLDE3LjExLDAsMCwxLDQuOTQtLjY3LDExLjU2LDExLjU2LDAsMCwxLDcuMywyLjA5cTIuNjcsMi4wOCwyLjY3LDYuNTZ2MTUuNDJhNSw1LDAsMCwxLS43OS4yMyw0LjQsNC40LDAsMCwxLTEuMDkuMTNxLTIuMTksMC0yLjE5LTEuODNWMTE3Ljg1QTUuMDksNS4wOSwwLDAsMCwxNy41MSwxMTMuNjhaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNTkuMjEsMTEzLjUyYTUuODMsNS44MywwLDAsMC0zLjgyLTEuMTcsOC41Nyw4LjU3LDAsMCwwLTUuOSwyLjM0LDcuNzMsNy43MywwLDAsMSwuMywyLjE5djE2LjE4YTUuMiw1LjIsMCwwLDEtLjc4LjIzLDQuNDgsNC40OCwwLDAsMS0xLjEuMTNxLTIuMTksMC0yLjE5LTEuODN2LTE0LjRhNC40OCw0LjQ4LDAsMCwwLTEuNDItMy42Nyw1LjkyLDUuOTIsMCwwLDAtMy44Ny0xLjE3LDkuMjYsOS4yNiwwLDAsMC0zLjA4LjUxQTExLjUxLDExLjUxLDAsMCwwLDM0Ljg5LDExNHYxOWE1LjM5LDUuMzksMCwwLDEtLjc3LjIzLDQuMzYsNC4zNiwwLDAsMS0xLjEyLjEzYy0xLjQ2LDAtMi4xOC0uNjEtMi4xOC0xLjgzVjExNC4yNGEzLjE1LDMuMTUsMCwwLDEsLjQzLTEuNzEsNSw1LDAsMCwxLDEuNS0xLjRBMTUuNzUsMTUuNzUsMCwwLDEsNDAuNDgsMTA5YTEyLjQzLDEyLjQzLDAsMCwxLDQuNDMuNzQsNi43Miw2LjcyLDAsMCwxLDMsMiwxMS4yOCwxMS4yOCwwLDAsMSwzLjMxLTJBMTIuMjksMTIuMjksMCwwLDEsNTUuNywxMDlhMTAuMjMsMTAuMjMsMCwwLDEsNi41NiwycTIuNDUsMiwyLjQ0LDZ2MTYuMDhhNSw1LDAsMCwxLS43OS4yMyw0LjQsNC40LDAsMCwxLTEuMDkuMTNxLTIuMTksMC0yLjE5LTEuODN2LTE0LjRBNC40OCw0LjQ4LDAsMCwwLDU5LjIxLDExMy41MloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik04OC45MiwxMjYuOTFBNiw2LDAsMCwxLDg2LjUzLDEzMnEtMi4zOSwxLjg0LTYuOTIsMS44NGExOCwxOCwwLDAsMS0zLjU2LS4zMywxMi41OCwxMi41OCwwLDAsMS0yLjc3LS44Nyw1LjU1LDUuNTUsMCwwLDEtMS43OC0xLjIyLDIsMiwwLDAsMS0uNjQtMS40LDIuMjUsMi4yNSwwLDAsMSwuMzMtMS4xNywyLjg4LDIuODgsMCwwLDEsMS0xLDE2LjMxLDE2LjMxLDAsMCwwLDMuMjEsMS44MSwxMC4zNywxMC4zNywwLDAsMCw0LjE3Ljc5cTUuMywwLDUuMjktMy41NmMwLTEuOTQtMS4xNy0zLjE5LTMuNTEtMy43N0w3Ny4xMiwxMjJhOS4xMyw5LjEzLDAsMCwxLTQuNTMtMi4zNyw1LjY1LDUuNjUsMCwwLDEtMS40Mi00LDYuMTksNi4xOSwwLDAsMSwuNTMtMi41NEE1Ljc1LDUuNzUsMCwwLDEsNzMuMzUsMTExYTguMzEsOC4zMSwwLDAsMSwyLjc4LTEuNDVBMTIuNTYsMTIuNTYsMCwwLDEsODAsMTA5LDEzLjQsMTMuNCwwLDAsMSw4NS43NywxMTBjMS40Ni42OSwyLjE5LDEuNSwyLjE5LDIuNDFhMi4wNiwyLjA2LDAsMCwxLTEuMjIsMS45NCwxNS43NywxNS43NywwLDAsMC0yLjYtMS4zMiwxMCwxMCwwLDAsMC00LS43Miw2LjY3LDYuNjcsMCwwLDAtMy42NC44NywyLjczLDIuNzMsMCwwLDAtMS4zNCwyLjQ0LDIuNzcsMi43NywwLDAsMCwuNzYsMiw0LjkxLDQuOTEsMCwwLDAsMi41NCwxLjIzbDMuNTEuODZhMTEuMDgsMTEuMDgsMCwwLDEsNS4xOSwyLjU3QTYuMTUsNi4xNSwwLDAsMSw4OC45MiwxMjYuOTFaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTAzLjEyLDEzMy44M2E5LjczLDkuNzMsMCwwLDEtNS43Ny0xLjU4cS0yLjIyLTEuNTgtMi4yMi01LjI0VjEwMi44NGE1LDUsMCwwLDEsLjc5LS4yMyw0LjY5LDQuNjksMCwwLDEsMS4xNC0uMTNjMS40MywwLDIuMTQuNjEsMi4xNCwxLjgzdjUuODVoOC4zNWE0LjI3LDQuMjcsMCwwLDEsLjMuNjksMi44NSwyLjg1LDAsMCwxLC4xNS45NGMwLDEuMTYtLjUsMS43My0xLjUyLDEuNzNIOTkuMnYxMy4yM2EzLjMyLDMuMzIsMCwwLDAsMS4xNSwyLjg4LDUuMzgsNS4zOCwwLDAsMCwzLjIzLjg0LDYuODgsNi44OCwwLDAsMCwxLjkzLS4zMSw3LjkzLDcuOTMsMCwwLDAsMS43OC0uNzEsMy4yNiwzLjI2LDAsMCwxLC41Ni43NiwyLjE3LDIuMTcsMCwwLDEsLjI2LDEuMDcsMi4wOCwyLjA4LDAsMCwxLTEuMzMsMS44M0E3LjcxLDcuNzEsMCwwLDEsMTAzLjEyLDEzMy44M1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjIuNjYsMTA5YTExLjMsMTEuMywwLDAsMSw3LDJxMi41OSwyLDIuNiw2LjI2VjEyOS4zYTIuODIsMi44MiwwLDAsMS0uNDQsMS43LDQuMzcsNC4zNywwLDAsMS0xLjI5LDEuMSwxMy4zMSwxMy4zMSwwLDAsMS0zLjIzLDEuMjQsMTcuOSwxNy45LDAsMCwxLTQuNjEuNTRxLTQuNzgsMC03LjQtMS44OWE2LjI3LDYuMjcsMCwwLDEtMi42Mi01LjQ0LDYsNiwwLDAsMSwyLjE4LTUuMDYsMTEuODEsMTEuODEsMCwwLDEsNi4xNi0yLjExbDcuMjMtLjcydi0xLjQyYTQuMzgsNC4zOCwwLDAsMC0xLjUzLTMuNzIsNi42MSw2LjYxLDAsMCwwLTQuMTItMS4xNywxMy4xMiwxMy4xMiwwLDAsMC00LC42MSwyMi4xMSwyMi4xMSwwLDAsMC0zLjM2LDEuMzgsNC44Niw0Ljg2LDAsMCwxLS43NC0uODIsMS42NywxLjY3LDAsMCwxLS4zMy0xLDEuODIsMS44MiwwLDAsMSwuMzYtMS4xNywzLjMsMy4zLDAsMCwxLDEuMTItLjg3LDEyLjQsMTIuNCwwLDAsMSwzLjE1LTEuMDlBMTguMTIsMTguMTIsMCwwLDEsMTIyLjY2LDEwOVptMCwyMS41M2ExMi41OCwxMi41OCwwLDAsMCwzLjU0LS40Myw4LjQ4LDguNDgsMCwwLDAsMi0uODR2LTcuMzhsLTYuMzEuNjZhNy44OSw3Ljg5LDAsMCwwLTMuOTIsMS4yLDMuMjEsMy4yMSwwLDAsMC0xLjI3LDIuNzcsMy40NCwzLjQ0LDAsMCwwLDEuNDcsM0E3Ljg2LDcuODYsMCwwLDAsMTIyLjcxLDEzMC41MloiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xNDcuNzQsMTMzLjgzYTkuNzUsOS43NSwwLDAsMS01Ljc3LTEuNThjLTEuNDgtMS4wNS0yLjIxLTIuOC0yLjIxLTUuMjRWMTAyLjg0YTQuODYsNC44NiwwLDAsMSwuNzgtLjIzLDQuNzEsNC43MSwwLDAsMSwxLjE1LS4xM2MxLjQyLDAsMi4xNC42MSwyLjE0LDEuODN2NS44NWg4LjM0YTQuMiw0LjIsMCwwLDEsLjMxLjY5LDIuODUsMi44NSwwLDAsMSwuMTUuOTRjMCwxLjE2LS41MSwxLjczLTEuNTMsMS43M2gtNy4yN3YxMy4yM2EzLjM1LDMuMzUsMCwwLDAsMS4xNCwyLjg4LDUuNCw1LjQsMCwwLDAsMy4yMy44NCw3LDcsMCwwLDAsMS45NC0uMzEsOC4xMyw4LjEzLDAsMCwwLDEuNzgtLjcxLDMuNTcsMy41NywwLDAsMSwuNTYuNzYsMi4xNywyLjE3LDAsMCwxLC4yNSwxLjA3LDIuMDgsMi4wOCwwLDAsMS0xLjMyLDEuODNBNy43Niw3Ljc2LDAsMCwxLDE0Ny43NCwxMzMuODNaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTYwLjc3LDEyMy44cTEuMzgsNi42Nyw4Ljc1LDYuNjdhMTAuMTUsMTAuMTUsMCwwLDAsMy44Ny0uNzEsMTEuNzEsMTEuNzEsMCwwLDAsMi43NS0xLjUzLDIuMTYsMi4xNiwwLDAsMSwxLjIyLDEuOTMsMiwyLDAsMCwxLS42NCwxLjM4LDUuNjksNS42OSwwLDAsMS0xLjczLDEuMTcsMTEuNDksMTEuNDksMCwwLDEtMi41NC44MSwxNS40NSwxNS40NSwwLDAsMS0zLjEzLjMxcS01LjkxLDAtOS4zNC0zLjIxdC0zLjQzLTkuMzZhMTQuNzksMTQuNzksMCwwLDEsLjg0LTUuMTcsMTEuMDcsMTEuMDcsMCwwLDEsMi4zNC0zLjg0LDEwLDEwLDAsMCwxLDMuNTktMi40MiwxMiwxMiwwLDAsMSw0LjUyLS44NCwxMS40MSwxMS40MSwwLDAsMSw0LjIzLjc3LDkuNjgsOS42OCwwLDAsMSwzLjMzLDIuMTYsMTAuMTcsMTAuMTcsMCwwLDEsMi4xOSwzLjMxLDExLDExLDAsMCwxLC43OSw0LjIsMi4xMywyLjEzLDAsMCwxLS41MSwxLjYsMi4zNywyLjM3LDAsMCwxLTEuNDMuNThabTctMTEuNWE2Ljc3LDYuNzcsMCwwLDAtNS4xNCwyLjE2LDkuMDYsOS4wNiwwLDAsMC0yLjEzLDYuMTlsMTQtMS45NGE3LjQ1LDcuNDUsMCwwLDAtMi00LjZBNi4yMSw2LjIxLDAsMCwwLDE2Ny43OSwxMTIuM1oiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik02Ni45MiwxMy4xM3Y5LjM5YzEuMjctLjA5LDIuNTQtLjE2LDMuODMtLjJWMTEuMzloLS4zM2E4My4yOSw4My4yOSwwLDAsMSwzMy4yNC03LjU0VjI3LjEyYzEuMy40NCwyLjU3LjkxLDMuODMsMS40VjMuODVBODMsODMsMCwwLDEsMTQxLjk0LDEyVjU1Ljc3aDMuODNWMTRjMTYuOCw5LjQyLDI4LjIsMjQuNTksMjkuNjgsNDEuODloMy44NEMxNzYuODMsMjQuNzMsMTQ0LjcxLDAsMTA1LjU4LDBjLTI2LDAtNDguODQsMTAuODktNjIsMjcuMzEsMi4yNy0uNzksNC42LTEuNDksNy0yLjExQTY3LjI4LDY3LjI4LDAsMCwxLDY2LjkyLDEzLjEzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTE0NC42OSw1OS42MWE1My44NCw1My44NCwwLDAsMSw2Ljc5LDIyLjY5bDI4LTIyLjZaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMTQ3LjgxLDg0LjMzYTUwLjM5LDUwLjM5LDAsMCwwLTcuNTQtMjQuNzNjLTctMTEuNTktMTguNTgtMjEuMDgtMzIuNzgtMjctMS4yNS0uNTItMi41My0xLTMuODMtMS40OEE4OC42LDg4LjYsMCwwLDAsNzMuOSwyNi4wOWMtMS4wNSwwLTIuMTEsMC0zLjE1LjA2LTEuMjksMC0yLjU2LjExLTMuODMuMjFhODcuNTgsODcuNTgsMCwwLDAtMjEuMDgsNC4yMWMtMi4xNS43Mi00LjI0LDEuNTEtNi4yOSwyLjM4QzE2LjU4LDQyLjc1LjY3LDYyLjA1LDAsODQuMzN2MS4yNWMwLDEuMjIuNywxLjgzLDIuMDksMS44M2E0LDQsMCwwLDAsMS4wNy0uMTMsNC41OCw0LjU4LDAsMCwwLC43My0uMjNWODQuMzNoMGMwLS40NywwLS45My4wNi0xLjQuMDktMS40My4yNS0yLjg0LjQ3LTQuMjRhNDUuNzQsNDUuNzQsMCwwLDEsMS42NS02Ljg0QzYuNSw3MC41MSw3LDY5LjIsNy41NCw2Ny45Yy4zNy0uODcuNzctMS43MiwxLjE4LTIuNTdhNTIuNzksNTIuNzksMCwwLDEsMi44MS00Ljk1LDU1LjYxLDU1LjYxLDAsMCwxLDUuMjctNi45MWMuMzItLjM2LjY2LS43MiwxLTEuMDgsMS0xLjA4LDIuMDctMi4xMiwzLjE3LTMuMTRzMi4yNS0yLDMuNDQtMi45NHEyLjM3LTEuOTEsNS0zLjYxYy44Ny0uNTcsMS43NS0xLjEzLDIuNjUtMS42Ni40NS0uMjcuOS0uNTQsMS4zNi0uOGwxLjg2LTF2NDUuMWgwdjEuMjVjMCwxLjIyLjY5LDEuODMsMi4wOSwxLjgzYTQsNCwwLDAsMCwxLjA3LS4xMyw1LjM5LDUuMzksMCwwLDAsLjczLS4yM1Y4NC4zM2gwbDAtMjVWMzcuNDloLS4zM2wxLjgtLjgyYy41My0uMjMsMS4wOC0uNDQsMS42Mi0uNjZzLjkzLS4zOSwxLjQtLjU3cTIuMy0uODgsNC42OC0xLjY0YTg0LjY2LDg0LjY2LDAsMCwxLDE4LjY4LTMuNTljMS4yNy0uMSwyLjU0LS4xNywzLjgzLS4yMmwxLjI0LDBWNTkuNDJsLS4wNiwyNC45MWgwdjEuMjVjMCwxLjIyLjcsMS44MywyLjA5LDEuODNhNCw0LDAsMCwwLDEuMDctLjEzLDUsNSwwLDAsMCwuNzMtLjIzVjg0LjMzaDBWMjkuOTRBODUuMDUsODUuMDUsMCwwLDEsOTkuNTYsMzMuOGMxLjM5LjQ0LDIuNzYuOTIsNC4xLDEuNDMuMi4wNy4zOS4xMy41OC4yMSwxLC4zOSwyLC44LDMsMS4yM2wuMjMuMTFjLjkxLjQsMS44Mi44MSwyLjcxLDEuMjRsLjA3LDBWODQuMzNoMHYxLjI1YS4yMi4yMiwwLDAsMCwwLC4wOHYuMTRoMGMuMDgsMS4wNy43NywxLjYxLDIuMDcsMS42MWE0LDQsMCwwLDAsMS4wNy0uMTMsNSw1LDAsMCwwLC43My0uMjNWODQuMzNoMGwtLjA2LTI0LjhWNDAuMDZsLjMzLjE4LDEuMzcuOGMuODkuNTMsMS43OCwxLjA5LDIuNjQsMS42NnEyLjU5LDEuNzEsNSwzLjYxYzEuMTkuOTQsMi4zMywxLjkzLDMuNDQsMi45NFMxMjksNTEuMzEsMTMwLDUyLjM5bDEsMS4wOGE1NS4wNiw1NS4wNiwwLDAsMSw0Ljc0LDYuMTJsLjUyLjc5YTUwLjY0LDUwLjY0LDAsMCwxLDIuODEsNC45NWMuNDIuODUuODEsMS43LDEuMTgsMi41Ny41NSwxLjMsMS4wNSwyLjYxLDEuNDgsMy45NWE0NS43MSw0NS43MSwwLDAsMSwxLjY0LDYuODQsNDIuNjIsNDIuNjIsMCwwLDEsLjQ4LDQuMjRjMCwuNjEsMCwxLjIzLjA2LDEuODV2LjhjMCwxLjIyLjcsMS44MywyLjA5LDEuODNhNCw0LDAsMCwwLDEuMDctLjEzLDQuNTgsNC41OCwwLDAsMCwuNzMtLjIzVjg0LjMzWiIvPjwvZz48L2c+PC9zdmc+
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          - clusterrolebindings
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - nmstate.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - configmaps
+          - namespaces
+          verbs:
+          - '*'
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+        serviceAccountName: nmstate-operator
+      deployments:
+      - name: nmstate-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: kubernetes-nmstate-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: kubernetes-nmstate-operator
+                name: kubernetes-nmstate-operator
+            spec:
+              containers:
+              - command:
+                - manager
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: OPERATOR_NAME
+                  value: kubernetes-nmstate-operator
+                - name: ENABLE_PROFILER
+                  value: "False"
+                - name: PROFILER_PORT
+                  value: "6060"
+                - name: RUN_OPERATOR
+                - name: HANDLER_IMAGE
+                  value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.10
+                - name: HANDLER_IMAGE_PULL_POLICY
+                  value: Always
+                - name: HANDLER_NAMESPACE
+                  value: openshift-nmstate
+                image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.10
+                imagePullPolicy: Always
+                name: nmstate-operator
+                resources: {}
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              serviceAccountName: nmstate-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+                operator: Exists
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - pods
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - '*'
+        serviceAccountName: nmstate-operator
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+        serviceAccountName: nmstate-handler
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - nmstate
+  - networking
+  - NetworkManager
+  links:
+  - name: Kubernetes Nmstate Operator
+    url: https://github.com/nmstate/kubernetes-nmstate
+  maintainers:
+  - email: support@redhat.com
+    name: Red Hat
+  maturity: GA
+  provider:
+    name: Red Hat, Inc.
+  selector:
+    matchLabels:
+      name: kubernetes-nmstate-operator
+  version: 4.10.0
+  labels:
+    olm-owner-enterprise-app: kubernetes-nmstate-operator
+    olm-status-descriptors: kubernetes-nmstate-operator.v4.10.0

--- a/manifests/4.10/nmstate.io_nmstates.yaml
+++ b/manifests/4.10/nmstate.io_nmstates.yaml
@@ -1,0 +1,337 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.0
+  creationTimestamp: null
+  name: nmstates.nmstate.io
+spec:
+  group: nmstate.io
+  names:
+    kind: NMState
+    listKind: NMStateList
+    plural: nmstates
+    singular: nmstate
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: NMState is the Schema for the nmstates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NMStateSpec defines the desired state of NMState
+            properties:
+              infraNodeSelector:
+                additionalProperties:
+                  type: string
+                description: InfraNodeSelector is an optional selector that will be
+                  added to webhook & certmanager Deployment manifests If InfraNodeSelector
+                  is specified, the webhook and certmanager will run only on nodes
+                  that have each of the indicated key-value pairs as labels applied
+                  to the node.
+                type: object
+              infraTolerations:
+                description: InfraTolerations is an optional list of tolerations to
+                  be added to webhook & certmanager Deployment manifests If InfraTolerations
+                  is specified, the handler daemonset will be able to be scheduled
+                  on nodes with corresponding taints
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is an optional selector that will be added
+                  to handler DaemonSet manifest for both workers and control-plane
+                  (https://github.com/nmstate/kubernetes-nmstate/blob/main/deploy/handler/operator.yaml).
+                  If NodeSelector is specified, the handler will run only on nodes
+                  that have each of the indicated key-value pairs as labels applied
+                  to the node.
+                type: object
+              tolerations:
+                description: Tolerations is an optional list of tolerations to be
+                  added to handler DaemonSet manifest If Tolerations is specified,
+                  the handler daemonset will be also scheduled on nodes with corresponding
+                  taints
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: NMStateStatus defines the observed state of NMState
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastHearbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    messageEncoded:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: NMState is the Schema for the nmstates API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NMStateSpec defines the desired state of NMState
+            properties:
+              infraNodeSelector:
+                additionalProperties:
+                  type: string
+                description: InfraNodeSelector is an optional selector that will be
+                  added to webhook & certmanager Deployment manifests If InfraNodeSelector
+                  is specified, the webhook and certmanager will run only on nodes
+                  that have each of the indicated key-value pairs as labels applied
+                  to the node.
+                type: object
+              infraTolerations:
+                description: InfraTolerations is an optional list of tolerations to
+                  be added to webhook & certmanager Deployment manifests If InfraTolerations
+                  is specified, the handler daemonset will be able to be scheduled
+                  on nodes with corresponding taints
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector is an optional selector that will be added
+                  to handler DaemonSet manifest for both workers and control-plane
+                  (https://github.com/nmstate/kubernetes-nmstate/blob/main/deploy/handler/operator.yaml).
+                  If NodeSelector is specified, the handler will run only on nodes
+                  that have each of the indicated key-value pairs as labels applied
+                  to the node.
+                type: object
+              tolerations:
+                description: Tolerations is an optional list of tolerations to be
+                  added to handler DaemonSet manifest If Tolerations is specified,
+                  the handler daemonset will be also scheduled on nodes with corresponding
+                  taints
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: NMStateStatus defines the observed state of NMState
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastHearbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    messageEncoded:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
@@ -2,6 +2,20 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "nmstate.io/v1beta1",
+        "kind": "NMState",
+        "metadata": {
+          "name": "nmstate",
+          "namespace":"openshift-nmstate"
+        },
+        "spec": {
+          "nodeSelector": {
+            "beta.kubernetes.io/arch": "amd64"
+          }
+        }
+      }
     alm-examples: |-
       [{
         "apiVersion": "nmstate.io/v1beta1",

--- a/manifests/kubernetes-nmstate-operator.package.yaml
+++ b/manifests/kubernetes-nmstate-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: kubernetes-nmstate-operator
 channels:
-  - name: "4.9"
-    currentCSV: kubernetes-nmstate-operator.v4.9.0
+  - name: "4.10"
+    currentCSV: kubernetes-nmstate-operator.v4.10.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Add OLM manifests for 4.10 release.
Addresses #218

**Release note**:
```release-note
Add OLM manifests for 4.10 release
```

/hold until we have the merge from upstream into downstream (add new API versions, ...)
