### PR TITLE
Fix OPM index build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ OPERATOR_SDK ?= $(GOBIN)/operator-sdk
 
 GINKGO = go run github.com/onsi/ginkgo/ginkgo
 CONTROLLER_GEN = go run sigs.k8s.io/controller-tools/cmd/controller-gen
-OPM = go run github.com/operator-framework/operator-registry/cmd/opm
+OPM = go run -tags=json1 github.com/operator-framework/operator-registry/cmd/opm
 
 LOCAL_REGISTRY ?= registry:5000
 
@@ -218,7 +218,7 @@ bundle-build:
 
 # Build the index
 index-build: $(GO) bundle-build
-	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(INDEX_IMG)
+	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(INDEX_IMG) --build-tool $(IMAGE_BUILDER)
 
 bundle-push: bundle-build
 	$(IMAGE_BUILDER) push $(BUNDLE_IMG)


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind enhancement

**What this PR does / why we need it**:
When running `make index-build`, it result in the following error:

```
...
INFO[0000] building the index                            bundles="[quay.io/creydr/kubernetes-nmstate-operator-bundle:0.0.1]"
Error: no such function: json_remove

Usage:
  opm index add [flags]
...
```
According to [BZ 1862845](https://bugzilla.redhat.com/show_bug.cgi?id=1862845), `opm` should be build with `make build`. Checking the [`build`](https://github.com/operator-framework/operator-registry/blob/c426f78b97458fe5f25208e4ecee398bbc7ae065/Makefile#L47) target, it sets the [`json1`](https://github.com/operator-framework/operator-registry/blob/c426f78b97458fe5f25208e4ecee398bbc7ae065/Makefile#L17) tag for `go build` (according to the comment needed for sqlite3).
When we add this tag for `go run <opm>`, `make index-build` runs successfully.

**Special notes for your reviewer**:
In addition, I added the `--build-tool $(IMAGE_BUILDER)`, for opm to use the defined image builder.

**Release note**:
```release-note
NONE
```
