### PR TITLE
Bug 2022447: Remove serviceaccount manifest

### DIFF
--- a/bundle/manifests/nmstate-operator_v1_serviceaccount.yaml
+++ b/bundle/manifests/nmstate-operator_v1_serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    nmstate.io: ""
-  name: nmstate-operator

--- a/manifests/4.8/nmstate-operator_v1_serviceaccount.yaml
+++ b/manifests/4.8/nmstate-operator_v1_serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    nmstate.io: ""
-  name: nmstate-operator
-

--- a/manifests/4.9/nmstate-operator_v1_serviceaccount.yaml
+++ b/manifests/4.9/nmstate-operator_v1_serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    nmstate.io: ""
-  name: nmstate-operator
-


### PR DESCRIPTION
This is no longer required[0] and may cause issues when newer versions
of the operator-sdk are used.

Note that I'm only removing back to 4.8, which is the oldest release where this is reported as a problem. I'm planning to leave 4.7 alone unless this also becomes a problem there.

0: https://github.com/operator-framework/operator-sdk/issues/5326

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Remove service account from manifests. This is no longer needed and conflicts with OLM's management of the service account.
```
