### PR TITLE
Skip e2e tests which are not supported on OVN

### DIFF
--- a/hack/ocp-e2e-tests.sh
+++ b/hack/ocp-e2e-tests.sh
@@ -19,9 +19,16 @@ export PRIMARY_NIC=enp2s0
 export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0
 
+SKIPPED_TESTS="user-guide|bridged"
+
 if oc get ns openshift-ovn-kubernetes &> /dev/null; then
     # We are using OVNKubernetes -> use enp1s0 as primary nic
     export PRIMARY_NIC=enp1s0
+    SKIPPED_TESTS+="|NodeNetworkConfigurationPolicy bonding default interface|\
+with ping fail|\
+when connectivity to default gw is lost after state configuration|\
+when name servers are lost after state configuration|\
+when name servers are wrong after state configuration"
 fi
 
 # Apply machine configs and wait until machine config pools got updated
@@ -45,4 +52,4 @@ while ! oc get pods -n nmstate | grep handler; do sleep 1; done
 # Then wait for them to be ready
 while oc get pods -n nmstate | grep "0/1"; do sleep 1; done
 # NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
-make test-e2e-handler E2E_TEST_ARGS="--skip=user-guide --skip=bridged" E2E_TEST_TIMEOUT=120m
+make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\"" E2E_TEST_TIMEOUT=120h


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

When running the e2e tests against an OVN OCP cluster, some test fail. This is as some tests assume to have the primary nic (`enp2s0` in our case) to be the default gateway. In case of ovn this is not the case as ovs configures `br-ex` as the default gateway. For example:

https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/bonding_default_interface_test.go#L49-L54

The following tests are skipped:

* 1 test in context `NodeNetworkConfigurationPolicy bonding default interface`: Actually it is the test `should successfully move default IP address on top of the bond` which is failing, but in the `BeforeEach` there is an assumption to have the primary nic as the default gateway. 
  https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/bonding_default_interface_test.go#L49-L54

* 2 tests in context `with ping fail`: Trys to assign an IP to the primary nic, which is expected to cause an invalid gateway config, but doesn't as the primary nic isn't the default gateway in case of ovn.
  https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/error_messages_formatting_test.go#L129-L131

* 1 test in context `when connectivity to default gw is lost after state configuration`: Trys to create an invalid gateway by using the primary nic, which doesn't "succeed" -> same reason as above
  https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/rollback_test.go#L97-L105

* 1 test in context `when name servers are lost after state configuration`: Are adding & removing dns resolvers in `BeforeEach` and `AfterEach` with having only the primary nic enabled
  https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/rollback_test.go#L129-L136

* 1 test in context `when name servers are wrong after state configuration`: Are adding & removing dns resolvers in `BeforeEach` and `AfterEach` with having only the primary nic enabled
  https://github.com/openshift/kubernetes-nmstate/blob/46c014bbb2d8a551211e1bcf2dd219b6b0e96ff3/test/e2e/handler/rollback_test.go#L157-L164

**Special notes for your reviewer**:
Slack discussion: https://coreos.slack.com/archives/CP7329Z5Z/p1637164066202600

**Release note**:
```release-note
NONE
```
