### PR TITLE
Add ppc64le and s390x to 4.10 CSV

### DIFF
--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -6,6 +6,8 @@ case $(uname -m) in
     i686)   architecture="386" ;;
     x86_64) architecture="amd64" ;;
     arm)    architecture="arm64" ;;
+    ppc64le)    architecture="ppc64le" ;;
+    s390x)    architecture="s390x" ;;
 esac
 
 destination=$1

--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -37,6 +37,8 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: kubernetes-nmstate-operator.v4.10.0
   namespace: openshift-nmstate
 spec:


### PR DESCRIPTION
Signed-off-by: Mick Tarsel <mtarsel@gmail.com>


**Is this a BUG FIX or a FEATURE ?**:

 /kind enhancement

**What this PR does / why we need it**:
Adds both ppc64le and s390x to 4.10 CSV to be included in operator hub.



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
