### PR TITLE
Upstream: <carry>: Fix JSON error in initialization resource

### DIFF
--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
         "kind": "NMState",
         "metadata": {
           "name": "nmstate"
-        },
+        }
       }
     alm-examples: |-
       [{


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>

/kind bug

> /kind enhancement

**What this PR does / why we need it**:
Fixes an JSON syntax error in the initialization resource:

```
Could not parse annotation operatorframework.io/initialization-resource as JSON:  SyntaxError: Unexpected token } in JSON at position 99
```

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```
