### PR TITLE
Remove service account from 4.7 manifest

### DIFF
--- a/manifests/4.7/nmstate-operator_v1_serviceaccount.yaml
+++ b/manifests/4.7/nmstate-operator_v1_serviceaccount.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  labels:
-    nmstate.io: ""
-  name: nmstate-operator
-


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
 /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Removes the manifest for the service account for 4.7, as done in #229 for 4.8 & 4.9.

**Release note**:
```release-note
Remove service account from manifests. This is no longer needed and conflicts with OLM's management of the service account.
```
