### PR TITLE
Switch to dnf in Openshift handler image

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -6,12 +6,12 @@ RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/hand
 FROM registry.ci.openshift.org/ocp/4.10:base
 
 RUN \
-    microdnf -y update && \
-    microdnf -y install \
+    dnf -y update && \
+    dnf -y install \
         nmstate \
         iputils \
         iproute && \
-    microdnf clean all
+    dnf clean all
 
 
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/manager  /usr/bin/


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
The current handler image for openshift has as base image `registry.ci.openshift.org/ocp/4.10:base`. This image does not include `microdnf`, so a build with ci-operator fails. This PR changes to use `dnf` instead.

**Special notes for your reviewer**:
The build for ART succeeds, as they are doing some replacement at the moment:
https://github.com/openshift/ocp-build-data/blob/4e8a5e21f0783ff0c790f2b7a298c8176fff2ad0/images/openshift-kubernetes-nmstate-handler.yml#L12-L15

I was wondering if this change should be done u/s, but I decided against, as this change should not be relevant for the u/s community as we are doing some image replacements for the builds anyhow (but I didn't see a reason why the images for Openshift kept in u/s as well).

**Release note**:
```release-note
none
```
