### PR TITLE
UPSTREAM: <carry>: enable all archs in nmstate example CR

### DIFF
--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -16,11 +16,6 @@ metadata:
         "kind": "NMState",
         "metadata": {
           "name": "nmstate"
-        },
-        "spec": {
-          "nodeSelector": {
-            "beta.kubernetes.io/arch": "amd64"
-          }
         }
       }]
     operatorframework.io/suggested-namespace: openshift-nmstate


### PR DESCRIPTION
Signed-off-by: Muhammad Adeel <muhammad.adeel@ibm.com>

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
When installing operator from OperatorHub the example nmstate CR still has nodeSelector only for amd64. This PR will remove the node selector so that CR on all archs can be created with clicking Create NMstate button.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
