### PR TITLE
Add ssh proxy for e2e tests when in CI

### DIFF
--- a/hack/ocp-e2e-tests.sh
+++ b/hack/ocp-e2e-tests.sh
@@ -14,12 +14,18 @@ export KUBEVIRT_PROVIDER=external
 export IMAGE_BUILDER=podman
 export DEV_IMAGE_REGISTRY=quay.io
 export KUBEVIRTCI_RUNTIME=podman
-export SSH=./hack/ssh.sh
 export PRIMARY_NIC=enp2s0
 export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0
 
 SKIPPED_TESTS="user-guide|bridged"
+
+if [ "${CI}" == "true" ]; then
+    source ${SHARED_DIR}/fix-uid.sh
+    export SSH=./hack/ssh-ci.sh
+else
+    export SSH=./hack/ssh.sh
+fi
 
 if oc get ns openshift-ovn-kubernetes &> /dev/null; then
     # We are using OVNKubernetes -> use enp1s0 as primary nic

--- a/hack/ssh-ci.sh
+++ b/hack/ssh-ci.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+node_name=${1}
+node_ip=$(oc get no ${node_name} -ojsonpath='{.status.addresses[?(.type=="InternalIP")].address}')
+IP="$(cat ${SHARED_DIR}/server-ip)"
+SSHOPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+       
+ssh ${SSHOPTS} -i ${CLUSTER_PROFILE_DIR}/packet-ssh-key root@${IP} "ssh ${SSHOPTS} core@${node_ip} -- ${@:3}"


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
When running e2e tests in CI, we need to use a proxy server to ssh to the nodes. Otherwise we will get timeouts:
```
./hack/ssh.sh worker-0 -- sudo ip -d link show type bridge br10
stdout: ...
, stderr ssh: connect to host 192.168.111.23 port 22: Connection timed out
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/24156/rehearse-24156-pull-ci-openshift-kubernetes-nmstate-master-e2e-sdn-ipv4/1471078781035745280/artifacts/e2e-sdn-ipv4/e2e/build-log.txt

This PR addresses it and uses the provided proxy to connect through on ssh when running in CI (env var `CI=true`).

**Special notes for your reviewer**:
The same behavior is currently tested directly in CI (overriding the existing `./hack/ssh.sh`) to validate this change.

https://github.com/openshift/release/commit/973c89bb4ee49cef5c49e22fbe681f87c163bc7c (https://github.com/openshift/release/pull/24156)
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24156/rehearse-24156-pull-ci-openshift-kubernetes-nmstate-master-e2e-sdn-ipv4/1471769365480214528

Of course this will be removed again from the https://github.com/openshift/release/pull/24156, after this change got merged (as https://github.com/openshift/release/commit/973c89bb4ee49cef5c49e22fbe681f87c163bc7c was only to verify this change / ssh opts).

**Release note**:
```release-note
none
```
