### PR TITLE
Bug 2039330: Remove initialization resource from CSV

### DIFF
--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -2,14 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    operatorframework.io/initialization-resource: |-
-      {
-        "apiVersion": "nmstate.io/v1",
-        "kind": "NMState",
-        "metadata": {
-          "name": "nmstate"
-        }
-      }
     alm-examples: |-
       [{
         "apiVersion": "nmstate.io/v1",


### PR DESCRIPTION
Per https://bugzilla.redhat.com/show_bug.cgi?id=2039330 the
initialization resource is not actually working, and having it
present in the CSV results in a confusing button that doesn't work.

The alm-example entry still makes it easy to create the necessary
resource for the operator so this isn't a significant loss, although
it would still be nice to figure out why this isn't working. In the
meantime, let's remove it to improve the user experience.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE, this was never released.
```
