### PR TITLE
Bug 2049142: Add operators app label in CSV

### DIFF
--- a/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
+++ b/manifests/4.10/kubernetes-nmstate-operator.v4.10.0.clusterserviceversion.yaml
@@ -103,6 +103,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:

--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -101,6 +101,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:

--- a/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
@@ -101,6 +101,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:

--- a/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
@@ -102,6 +102,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Currently the CSVs deploymentsSpec does not contain the labels of the operator deployment. This is required, as the CNV operator checks by these labels if already a k-nmstate operator is installed in the cluster ([BZ 2030716](https://bugzilla.redhat.com/show_bug.cgi?id=2030716)). 
This PR adds the operators labels to the CSV.

**Special notes for your reviewer**:
It seems to be a bug in the operator-sdk to ignore the deployments labels and not add it in the CSV. I have created a PR with a fix but until this got merged and we have the latest version, we need to add them manually (instead of using the generated CSV from the bundle).

**Release note**:
```release-note
none
```
