### PR TITLE
Bug 2052840: Do not ignore parameters for ocp tests

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -11,9 +11,9 @@
 set -ex
 
 export KUBEVIRT_PROVIDER=external
-export IMAGE_BUILDER=podman
-export DEV_IMAGE_REGISTRY=quay.io
-export KUBEVIRTCI_RUNTIME=podman
+export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
+export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
+export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
 export PRIMARY_NIC=enp2s0
 export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0

--- a/hack/ocp-e2e-tests-operator.sh
+++ b/hack/ocp-e2e-tests-operator.sh
@@ -11,9 +11,9 @@
 set -ex
 
 export KUBEVIRT_PROVIDER=external
-export IMAGE_BUILDER=podman
-export DEV_IMAGE_REGISTRY=quay.io
-export KUBEVIRTCI_RUNTIME=podman
+export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
+export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
+export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
 
 make cluster-sync-operator
 make test-e2e-operator


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
Currently set some env vars hard to values and ignore if the user provide alternative values. E.g. in case the user uses docker instead of podman for the image build, the IMAGE_BUILDER parameter is ignored. This PR addresses it and uses only the default values, if the values are not already set (e.g. as parameters in form of `IMAGE_BUILDER=docker make test-e2e-operator-ocp`)

**Special notes for your reviewer**:
-

**Release note**:
```release-note
none
```
