### PR TITLE
Bug 2056607: Run nmstate-hack.service before ovs-configuration

### DIFF
--- a/test/e2e/machineconfigs.yaml
+++ b/test/e2e/machineconfigs.yaml
@@ -13,12 +13,20 @@ spec:
       - contents: |
           [Unit]
           Description=NMState e2e hack
-          Wants=crio.service
-          Before=kubelet.service
-          After=crio.service
+          Wants=NetworkManager-wait-online.service
+          Before=ovs-configuration.service
+          After=NetworkManager-wait-online.service
           [Service]
           Type=oneshot
-          ExecStart=/bin/bash -c "for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; done"
+          ExecStart=/bin/bash -c " \
+                        echo '[main]\nno-auto-default=enp3s0,enp4s0\n' > /etc/NetworkManager/conf.d/90-no-auto-default.conf; \
+                        for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do \
+                          nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; \
+                        done; \
+                        nmcli network off; \
+                        systemctl restart NetworkManager; \
+                        nmcli network on; \
+                        nm-online -s -t 60;"
           [Install]
           WantedBy=multi-user.target
         enabled: true
@@ -40,12 +48,20 @@ spec:
       - contents: |
           [Unit]
           Description=NMState e2e hack
-          Wants=crio.service
-          Before=kubelet.service
-          After=crio.service
+          Wants=NetworkManager-wait-online.service
+          Before=ovs-configuration.service
+          After=NetworkManager-wait-online.service
           [Service]
           Type=oneshot
-          ExecStart=/bin/bash -c "for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; done"
+          ExecStart=/bin/bash -c " \
+                        echo '[main]\nno-auto-default=enp3s0,enp4s0\n' > /etc/NetworkManager/conf.d/90-no-auto-default.conf; \
+                        for i in $(nmcli --fields NAME,UUID -t con show | grep 'Wired Connection' | awk -F : '{print $2}'); do \
+                          nmcli con modify $i match.interface-name '!enp3s0, !enp4s0'; \
+                        done; \
+                        nmcli network off; \
+                        systemctl restart NetworkManager; \
+                        nmcli network on; \
+                        nm-online -s -t 60;"
           [Install]
           WantedBy=multi-user.target
         enabled: true


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
In the nmstate-hack systemd unit, we configure the connection profiles. This should run before the ovs-configuration and reload the NWManager afterwards.

**Special notes for your reviewer**:
This is just needed for the e2e tests!

**Release note**:
```release-note
NONE
```

**How to verify**:
This allows us to run the e2e tests against OVN clusters again.
1. Create a OVN cluster with dev-scripts (use `NETWORK_TYPE="OVNKubernetes"` in your config)
2. Start the e2e tests: `IMAGE_REPO=<your quay user> KUBECONFIG=<path to kubeconfig> make test-e2e-handler-ocp`
3. machineconfigs should be applied and e2e tests should start -> you should see something similar to 
```
machineconfigpool.machineconfiguration.openshift.io/master condition met
machineconfigpool.machineconfiguration.openshift.io/worker condition met
....
....
....
Running Suite: E2E Test Suite
=============================
Random Seed: 1644604398
Will run 55 of 86 specs
```
