### PR TITLE
UPSTREAM: <carry>: Fix ssh-ci.sh for dualstack environments

### DIFF
--- a/hack/ssh-ci.sh
+++ b/hack/ssh-ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 node_name=${1}
-node_ip=$(oc get no ${node_name} -ojsonpath='{.status.addresses[?(.type=="InternalIP")].address}')
+node_ip=$(oc get node ${node_name} --no-headers -o wide | awk '{print $6}')
 IP="$(cat ${SHARED_DIR}/server-ip)"
 SSHOPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
        


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
In dualstack envs `oc get no ${node_name} -ojsonpath='{.status.addresses[?(.type=="InternalIP")].address}` returns both IPs of the node. E.g. 
```
$ oc get no master-0.ostest.test.metalkube.org -ojsonpath='{.status.addresses[?(.type=="InternalIP")].address}
192.168.111.20 fd2e:6f44:5dd8:c956::14
```
This leads to issues in the ssh-ci.sh, as it takes then the 2nd IP as a parameter/command. 
This PR addresses it and just takes the IP displayed in `oc get node -o wide`.

Blocks https://github.com/openshift/release/pull/25547

**Release note**:
```release-note
NONE
```
