### PR TITLE
[release-4.9] Bug 2054277: Add operators app label in CSV

### DIFF
--- a/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/kubernetes-nmstate-operator.v4.7.0.clusterserviceversion.yaml
@@ -103,6 +103,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:

--- a/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/kubernetes-nmstate-operator.v4.8.0.clusterserviceversion.yaml
@@ -103,6 +103,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:

--- a/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/kubernetes-nmstate-operator.v4.9.0.clusterserviceversion.yaml
@@ -104,6 +104,8 @@ spec:
         serviceAccountName: nmstate-operator
       deployments:
       - name: nmstate-operator
+        label:
+          app: kubernetes-nmstate-operator
         spec:
           replicas: 1
           selector:


### PR DESCRIPTION
Backport of #256 to 4.9. Only "removed" the manifests for 4.10, otherwise the same.

```release-note
none
```
