### PR TITLE
Rerun flaky e2e tests

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -17,6 +17,7 @@ export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
 export PRIMARY_NIC=enp2s0
 export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0
+export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-5}"
 
 SKIPPED_TESTS="user-guide|bridged"
 
@@ -56,4 +57,4 @@ while ! oc get pods -n nmstate | grep handler; do sleep 1; done
 # Then wait for them to be ready
 while oc get pods -n nmstate | grep "0/1"; do sleep 1; done
 # NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
-make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\"" E2E_TEST_TIMEOUT=120h
+make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flakeAttempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=120h

--- a/hack/ocp-e2e-tests-operator.sh
+++ b/hack/ocp-e2e-tests-operator.sh
@@ -14,6 +14,7 @@ export KUBEVIRT_PROVIDER=external
 export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
 export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
 export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
+export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-5}"
 
 make cluster-sync-operator
-make test-e2e-operator
+make test-e2e-operator E2E_TEST_ARGS="--flakeAttempts=${FLAKE_ATTEMPTS}"


### PR DESCRIPTION
Sometimes we have the e2e suites failing due to some flaky tests. This PR adds the `--flakeAttempts` parameter and reruns failed tests at a max. 5 times, so the whole suite does not fail due to a flake.