### PR TITLE
Bug 2086301: Fix 4.11 manifest to use correct handler image and namespace

### DIFF
--- a/manifests/4.11/kubernetes-nmstate-operator.v4.11.0.clusterserviceversion.yaml
+++ b/manifests/4.11/kubernetes-nmstate-operator.v4.11.0.clusterserviceversion.yaml
@@ -146,12 +146,12 @@ spec:
                   value: "6060"
                 - name: RUN_OPERATOR
                 - name: HANDLER_IMAGE
-                  value: quay.io/nmstate/kubernetes-nmstate-handler:latest
+                  value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.11
                 - name: HANDLER_IMAGE_PULL_POLICY
                   value: Always
                 - name: HANDLER_NAMESPACE
-                  value: nmstate
-                image: quay.io/nmstate/kubernetes-nmstate-operator:latest
+                  value: openshift-nmstate
+                image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.11
                 imagePullPolicy: Always
                 name: nmstate-operator
                 resources:


### PR DESCRIPTION
In 36e01dcf6af51217a94c21949adbb42532d27f24 I updated the CSV files, but used the upstream handler image and namespace. This PR fixes it.