### PR TITLE
[release-4.8] Use git config to get origins remote URL

### DIFF
--- a/cluster/kubevirtci.sh
+++ b/cluster/kubevirtci.sh
@@ -7,7 +7,7 @@ KUBEVIRTCI_PATH="${PWD}/_kubevirtci"
 export KUBEVIRTCI_TAG='2102030941-4a15921'
 
 function kubevirtci::_get_repo() {
-    git --git-dir ${KUBEVIRTCI_PATH}/.git remote get-url origin
+    git --git-dir ${KUBEVIRTCI_PATH}/.git config --get remote.origin.url
 }
 
 function kubevirtci::_get_version() {


### PR DESCRIPTION
CI images for 4.8 seems to have an older Git version which does not
support `git remote get-url xyz`.

Running the e2e tests locally results in passing tests:
```
Ran 34 of 54 Specs in 2291.877 seconds
SUCCESS! -- 34 Passed | 0 Failed | 0 Flaked | 2 Pending | 18 Skipped
PASS
```

Running them in CI complains about git remote get-url (see [1536257811007148032](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29398/rehearse-29398-pull-ci-openshift-kubernetes-nmstate-release-4.8-e2e-handler-sdn-ipv4/1536257811007148032) in https://github.com/openshift/release/pull/29398):
```
....
+ ./cluster/kubectl.sh apply -f build/_output/manifests/service_account.yaml
error: Unknown subcommand: get-url
usage: git remote [-v | --verbose]
   or: git remote add [-t <branch>] [-m <master>] [-f] [--tags|--no-tags] [--mirror=<fetch|push>] <name> <url>
   or: git remote rename <old> <new>
   or: git remote remove <name>
   or: git remote set-head <name> (-a | -d | <branch>)
   or: git remote [-v | --verbose] show [-n] <name>
   or: git remote prune [-n | --dry-run] <name>
   or: git remote [-v | --verbose] update [-p | --prune] [(<group> | <remote>)...]
   or: git remote set-branches [--add] <name> <branch>...
   or: git remote set-url [--push] <name> <newurl> [<oldurl>]
   or: git remote set-url --add <name> <newurl>
   or: git remote set-url --delete <name> <url>
    -v, --verbose         be verbose; must be placed before a subcommand
./cluster/kubevirtci.sh: line 20: [: too many arguments
....
```

This PR addresses it and changes the kubevirtci to get the remote url from the config.



Additional info:
In [1536316472614195200](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29398/rehearse-29398-pull-ci-openshift-kubernetes-nmstate-release-4.8-e2e-handler-sdn-ipv4/1536316472614195200) I updated the kubevirtci.sh to use `git config --get remote.origin.url` and the tests started (but failed due to a failing test (currently investigating about the failure (locally they pass))