### PR TITLE
UPSTREAM: <carry>: Skip rollback e2e test

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -19,7 +19,7 @@ export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0
 export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-5}"
 
-SKIPPED_TESTS="user-guide|bridged"
+SKIPPED_TESTS="user-guide|bridged|should rollback failed state configuration"
 
 if [ "${CI}" == "true" ]; then
     source ${SHARED_DIR}/fix-uid.sh


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:
Currently we have the `Skip rollback e2e test` e2e test failing in 4.8 (was removed in 4.9). This PR skips it in CI, because it uses a file, which seems not to exist in the 4.8 image:

```
[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]rollback when an error happens during state configuration 
  should rollback failed state configuration
  /go/src/github.com/openshift/kubernetes-nmstate/test/e2e/handler/rollback_test.go:106
STEP: Setting bond1=bond8
STEP: Setting bridge1=br8
STEP: Getting nodes initial state
STEP: Rename vlan-filtering to vlan-filtering.bak to force failure during state configuration
./cluster/kubectl.sh get pod -n nmstate --no-headers=true -o custom-columns=:metadata.name -l component=kubernetes-nmstate-handler
stdout: nmstate-handler-c9xjk
nmstate-handler-dndnh
nmstate-handler-ftplw
nmstate-handler-kzvxd
nmstate-handler-mkt42
nmstate-handler-n8lvd
...
, stderr 
./cluster/kubectl.sh exec -n nmstate nmstate-handler-c9xjk -- mv /usr/local/bin/vlan-filtering /usr/local/bin/vlan-filtering.bak
stdout: ...
, stderr mv: cannot stat '/usr/local/bin/vlan-filtering': No such file or directory
command terminated with exit code 1

STEP: Rename vlan-filtering.bak to vlan-filtering to leave it as it was
./cluster/kubectl.sh get pod -n nmstate --no-headers=true -o custom-columns=:metadata.name -l component=kubernetes-nmstate-handler
stdout: nmstate-handler-c9xjk
nmstate-handler-dndnh
nmstate-handler-ftplw
nmstate-handler-kzvxd
nmstate-handler-mkt42
nmstate-handler-n8lvd
...
, stderr 
./cluster/kubectl.sh exec -n nmstate nmstate-handler-c9xjk -- mv /usr/local/bin/vlan-filtering.bak /usr/local/bin/vlan-filtering
stdout: ...
, stderr mv: cannot stat '/usr/local/bin/vlan-filtering.bak': No such file or directory
command terminated with exit code 1

STEP: Verifying initial state
STEP: Verifying initial state eventually
STEP: Verifying initial state eventually
STEP: Verifying initial state eventually
STEP: Verifying initial state eventually
STEP: Verifying initial state eventually
STEP: Verifying initial state eventually

• Failure in Spec Setup (BeforeEach) [1.750 seconds]
[rfe_id:3503][crit:medium][vendor:cnv-qe@redhat.com][level:component]rollback
/go/src/github.com/openshift/kubernetes-nmstate/test/e2e/handler/rollback_test.go:94
  when an error happens during state configuration
  /go/src/github.com/openshift/kubernetes-nmstate/test/e2e/handler/rollback_test.go:95
    should rollback failed state configuration [BeforeEach]
    /go/src/github.com/openshift/kubernetes-nmstate/test/e2e/handler/rollback_test.go:106

    Unexpected error:
        <*exec.ExitError | 0xc0009300e0>: {
            ProcessState: {
                pid: 22696,
                status: 256,
                rusage: {
                    Utime: {Sec: 0, Usec: 189154},
                    Stime: {Sec: 0, Usec: 79253},
                    Maxrss: 91980,
                    Ixrss: 0,
                    Idrss: 0,
                    Isrss: 0,
                    Minflt: 6678,
                    Majflt: 1,
                    Nswap: 0,
                    Inblock: 184,
                    Oublock: 0,
                    Msgsnd: 0,
                    Msgrcv: 0,
                    Nsignals: 0,
                    Nvcsw: 978,
                    Nivcsw: 0,
                },
            },
            Stderr: nil,
        }
        exit status 1
    occurred

    /go/src/github.com/openshift/kubernetes-nmstate/test/runner/pod.go:44
```