### PR TITLE
Rename deprecated flake attempts parameter

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -59,4 +59,4 @@ while ! oc get pods -n nmstate | grep handler; do sleep 1; done
 # Then wait for them to be ready
 while oc get pods -n nmstate | grep "0/1"; do sleep 1; done
 # NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
-make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flakeAttempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=120h
+make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=120h

--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -59,4 +59,4 @@ while ! oc get pods -n nmstate | grep handler; do sleep 1; done
 # Then wait for them to be ready
 while oc get pods -n nmstate | grep "0/1"; do sleep 1; done
 # NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
-make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=120h
+make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=4h

--- a/hack/ocp-e2e-tests-operator.sh
+++ b/hack/ocp-e2e-tests-operator.sh
@@ -24,4 +24,4 @@ else
 fi
 
 make cluster-sync-operator
-make test-e2e-operator E2E_TEST_ARGS="--flakeAttempts=${FLAKE_ATTEMPTS}"
+make test-e2e-operator E2E_TEST_ARGS="--flake-attempts=${FLAKE_ATTEMPTS}"


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The ginkgo parameter `flakeAttempts` was deprecated:
```
...
You're using deprecated Ginkgo functionality:
=============================================
  --flakeAttempts is deprecated, use --flake-attempts instead
```
This PR addresses it and uses the new parameter.

**Special notes for your reviewer**:
In addition this PR adjusts the timeout for the handler e2e tests to a bit more usable value.

**Release note**:
```release-note
none
```
