### PR TITLE
Bug 2106935: Fix OLM skiprange replacement

### DIFF
--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
     # replace entire version line, otherwise would replace {MAJOR}.{MINOR}.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.4.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.4.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.3.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
   - file: "kubernetes-nmstate-operator.package.yaml"
     update_list:
     - search: "currentCSV: kubernetes-nmstate-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
Currently we see some `no channel heads (entries not replaced by another entry) found in channel "stable" of package "kubernetes-nmstate-operator"` in the operator subscriptions. This is because there are multiple candidates (msg seems to be misleading according to [this](https://coreos.slack.com/archives/C3VS0LV41/p1652446407094869) discussion.
This PR addresses it and fixes the wrong olm.skipRange replacement (in the CSV we defined it from 4.4.0, whereas ART searches for 4.3.0 and therefor doesn't get found:

https://github.com/openshift/kubernetes-nmstate/blob/539d52e66474aec3445325c23e20b8165c29ef59/manifests/4.11/kubernetes-nmstate-operator.v4.11.0.clusterserviceversion.yaml#L22

vs

https://github.com/openshift/kubernetes-nmstate/blob/539d52e66474aec3445325c23e20b8165c29ef59/manifests/art.yaml#L10-L11
)

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```
