### PR TITLE
tmp: Skip failing e2e test on OpenShiftSDN

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -36,6 +36,8 @@ with ping fail|\
 when connectivity to default gw is lost after state configuration|\
 when name servers are lost after state configuration|\
 when name servers are wrong after state configuration"
+elif oc get ns openshift-sdn &> /dev/null; then
+    SKIPPED_TESTS+="|should discard disarranged parts of the message and keep desired parts of the message"
 fi
 
 # Apply machine configs and wait until machine config pools got updated


### PR DESCRIPTION
Currently we can't merge any new PR as the e2e test `should discard disarranged parts of message and keep desired parts of message` fails due to https://bugzilla.redhat.com/show_bug.cgi?id=2111945.
As CI is blocked and we can't continue with bug fixing, we excluded this e2e test temporarily.

This commit should be reverted as soon as the BZ is fixed and the test runs on OpenShiftSDN again.

/hold to wait for @cybertron