### PR TITLE
Reminder: Revert "tmp: Skip failing e2e test on OpenShiftSDN"

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -38,8 +38,6 @@ when connectivity to default gw is lost after state configuration|\
 when name servers are lost after state configuration|\
 when name servers are wrong after state configuration|\
 LLDP configuration with nmpolicy"
-elif oc get ns openshift-sdn &> /dev/null; then
-    SKIPPED_TESTS+="|should discard disarranged parts of the message and keep desired parts of the message"
 fi
 
 # Apply machine configs and wait until machine config pools got updated


### PR DESCRIPTION
**What this PR does / why we need it**:

In #291 we skipped an permafailing e2e on OpenshiftSDN. This PR reverts it.

**Special notes for your reviewer**:
This PR is a reminder

/hold
until https://bugzilla.redhat.com/show_bug.cgi?id=2111945 is fixed