### PR TITLE
Update bundle manifests after operator-sdk update to 1.22

### DIFF
--- a/manifests/4.12/bundle.Dockerfile
+++ b/manifests/4.12/bundle.Dockerfile
@@ -7,13 +7,9 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kubernetes-nmstate-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=4.12,alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=4.12
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.21.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
-
-# Labels for testing.
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Copy files to locations specified by labels.
 COPY manifests/4.12/manifests /manifests/

--- a/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -69,7 +69,7 @@ metadata:
     olm.skipRange: '>=4.3.0 <4.12.0'
     operatorframework.io/suggested-namespace: openshift-nmstate
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.21.0
+    operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/kubernetes-nmstate
     support: Red Hat, Inc.

--- a/manifests/4.12/metadata/annotations.yaml
+++ b/manifests/4.12/metadata/annotations.yaml
@@ -6,10 +6,6 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: kubernetes-nmstate-operator
   operators.operatorframework.io.bundle.channels.v1: 4.12,alpha
   operators.operatorframework.io.bundle.channel.default.v1: 4.12
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.21.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-
-  # Annotations for testing.
-  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
-  operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
After da609f9f5 I didn't update the bundle manifests :man_facepalming:. 

This leads to rehearse failures in openshift/release/pull/30856. This PR addresses it.
In future openshift/release/pull/30856 should remind us about such issues.