### PR TITLE
[release-4.11] OCPBUGS-1719: Backport: handler: Install plugin-ovsdb

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -9,6 +9,7 @@ RUN \
     dnf -y update && \
     dnf -y install \
         nmstate \
+        nmstate-plugin-ovsdb \
         iputils \
         iproute && \
     dnf clean all

--- a/build/install-nmstate.distro.sh
+++ b/build/install-nmstate.distro.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -xe
 
-dnf install -b -y -x "*alpha*" -x "*beta*" nmstate
+dnf install -b -y -x "*alpha*" -x "*beta*" nmstate nmstate-plugin-ovsdb

--- a/build/install-nmstate.git.sh
+++ b/build/install-nmstate.git.sh
@@ -2,4 +2,4 @@
 
 dnf install -b -y dnf-plugins-core
 dnf copr enable -y nmstate/nmstate-git
-dnf install -b -y nmstate
+dnf install -b -y nmstate nmstate-plugin-ovsdb


### PR DESCRIPTION
Backporting ef5ca2fe6 to 4.11 release to fix [OCPBUGS-1719](https://issues.redhat.com/browse/OCPBUGS-1719)