### PR TITLE
Add helper scripts (install nightly ART operator bundles & capture NM logs)

### DIFF
--- a/hack/ocp-devscripts-nm-logging.sh
+++ b/hack/ocp-devscripts-nm-logging.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# This script captures the logs of network manager, network manager dispatcher
+# and the entire journal of the cluster nodes created by dev-scripts. 
+# This script may not run outside the VM host!
+
+set -e
+
+pids=()
+nodes=()
+
+if ! sudo virsh list | grep ostest >/dev/null; then
+    echo "This script can only be run on the VM host as it needs direct ssh access to the VMs"
+    exit 1
+fi
+
+echo "Getting cluster nodes..."
+for node in $(oc get no -ojsonpath='{.items[*].metadata.name}'); do 
+	nodes+=( ${node%%.*} )
+done
+
+read -p "Do you want me to cleanup ~/.ssh/known_hosts file and add the new keys of the cluster nodes? (y/n) " yn
+case $yn in
+	[yY] ) 
+		for no in ${nodes[@]}; do sed -i "/^${no}/d" ~/.ssh/known_hosts; done
+		for no in ${nodes[@]}; do ssh-keyscan -t ecdsa ${no} >> ~/.ssh/known_hosts; done
+		;;
+	[nN] ) 
+		echo "Not cleaning up"
+		;;
+	* ) 
+		echo "Invalid response"
+		exit 1;;
+esac
+
+read -p "Do you want me to enable trace logging in NetworkManager? (y/n) " yn
+case $yn in
+	[yY] ) 
+		echo "Enable trace logging in NetworkManager..."
+		for node in ${nodes[@]}; do
+			ssh core@${node} sudo sed -i 's/^\#*level=.*$/level=TRACE/g' /etc/NetworkManager/NetworkManager.conf
+			ssh core@${node} sudo systemctl restart NetworkManager
+            echo "Trace logging enabled on ${node}"
+		done
+		;;
+	[nN] ) 
+		echo "No trace logging enabled"
+		;;
+	* ) 
+		echo "Invalid response"
+		exit 1;;
+esac
+
+read -p "Press any key to start logging... " -n1 -s
+echo
+echo "Starting logging jobs..."
+date
+
+mkdir -p out/
+for node in ${nodes[@]}; do
+	echo "starting on node ${node} in background..."
+	ssh core@${node} sudo journalctl --since now -xefu NetworkManager > out/networkmanager_${node}.log &
+	pids+=( "$!" )
+	
+	ssh core@${node} sudo journalctl --since now -xefu NetworkManager-dispatcher > out/networkmanager-dispatcher_${node}.log &
+    pids+=( "$!" )
+
+	ssh core@${node} sudo journalctl --since now -xef > out/journal_${node}.log &
+    pids+=( "$!" )
+done
+
+read -p "Press any key to stop logging... " -n1 -s
+echo
+
+for pid in ${pids[@]}; do
+	kill $pid
+done
+date
+
+echo "Done"

--- a/hack/ocp-install-nightly-art-operators.sh
+++ b/hack/ocp-install-nightly-art-operators.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# This script is an automation of steps 1-7 from
+# https://hackmd.io/0vbbJdZ7RXem69vCWI61ug to install the nightly ART bundle
+# build of the OpenShift operators.  The script requires the user to have a
+# employee-token created at least once before
+# (https://source.redhat.com/groups/public/teamnado/wiki/brew_registry).
+
+set -eo pipefail
+
+function wait_for_all_nodes_ready() {
+  i=20
+  while [ $i -gt 0 ]; do
+    if [[ $(oc get no | grep SchedulingDisabled) ]]; then
+      # reset timer
+      i=20
+      echo "found node with SchedulingDisabled. Resetting timer..."
+    else
+      echo "Waiting ${i} times to ensure all nodes are ready..."
+      i=$((i - 1))
+    fi
+
+    sleep 1
+  done
+}	
+
+brew_credentials=$(curl --negotiate -u : https://employee-token-manager.registry.redhat.com/v1/tokens -s) #make sure you created a token before (https://source.redhat.com/groups/public/teamnado/wiki/brew_registry)
+if [[ "${brew_credentials}" == "null" ]]; then
+  echo "No Brew token found. Trying to create a token..."
+  # Brew token does not exist. Create one
+  brew_credentials=$(curl --negotiate -u : -X POST -H 'Content-Type: application/json' --data '{"description":"openshift 4 testing"}' https://employee-token-manager.registry.redhat.com/v1/tokens -s)
+  if [[ -z "$brew_credentials" ]] || [[ "$brew_credentials" == "null" ]]; then
+    echo "Could not create a Brew token for you. Please visit https://source.redhat.com/groups/public/teamnado/wiki/brew_registry for more information about creating the Brew token manually." 
+    exit 1
+  fi
+  echo "Brew token created"
+  brew_credentials="["${brew_credentials}"]" # convert to json array
+fi
+
+brew_username=$(echo $brew_credentials | jq -r ".[0].credentials.username")
+brew_password=$(echo $brew_credentials | jq -r ".[0].credentials.password")
+
+cluster_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' | cut -d '.' -f 1,2)
+
+oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources","value": true}]'
+oc get secret/pull-secret -n openshift-config -o json | jq -r '.data.".dockerconfigjson"' | base64 -d > authfile
+if ! podman login --authfile authfile --username "${brew_username}" --password "${brew_password}" brew.registry.redhat.io; then
+  rm authfile # make sure the authfile is deleted in case of an error
+  exit 1
+fi
+
+if ! oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=authfile; then
+  rm authfile # make sure the authfile is deleted in case of an error
+  exit 1
+fi
+
+rm authfile
+oc patch image.config.openshift.io/cluster --type merge -p '{"spec":{"registrySources":{"insecureRegistries":["registry-proxy.engineering.redhat.com"]}}}'
+
+wait_for_all_nodes_ready
+
+cat <<EOF | oc apply -f -
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: brew-registry
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry.stage.redhat.io
+  - mirrors:
+    - brew.registry.redhat.io
+    source: registry-proxy.engineering.redhat.com
+EOF
+
+wait_for_all_nodes_ready
+
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: my-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/openshift-release-dev/ocp-release-nightly:iib-int-index-art-operators-${cluster_version}
+  displayName: My Operator Catalog
+  publisher: grpc
+EOF


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind enhancement

**What this PR does / why we need it**:
This PR adds 2 helper scripts which I used often when working with k-nmstate on OCP:

* `hack/ocp-devscripts-nm-logging.sh`: Script which captures the logs of network manager, network manager dispatcher and the entire journal logs in the background and saves them to disk. This can be helpful if some issues with NM arise and logs needs to attached to a case. In its current state, the script can only be run on the dev-script host machine.
* `hack/ocp-install-nightly-art-operators.sh`: This is an automation of https://hackmd.io/0vbbJdZ7RXem69vCWI61ug to install the latest nightly ART build of the operator bundle (in case you want to test the ART bundles in contrast to using `make ocp-build-and-deploy-bundle` (from 43df3463cfca8febc398e680a07e5942b325a30a)).

**Special notes for your reviewer**:
The scripts don't cover all corner cases (e.g. `hack/ocp-install-nightly-art-operators.sh` if the user has multiple tokens available and the required one is not on 1st place in the array), but the scripts helped me often and I thought it might be worth sharing them.

**Release note**:
```release-note
none
```
