### PR TITLE
[release-4.11] OCPBUGS-2925: Backport lldp filtering fix

### DIFF
--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -328,7 +328,7 @@ func (r *NodeNetworkConfigurationPolicyReconciler) fillInEnactmentStatus(
 		return err
 	}
 
-	capturedStates, desiredStateMetaInfo, generatedDesiredState, err := nmpolicy.GenerateState(
+	capturedStates, generatedDesiredState, err := nmpolicy.GenerateState(
 		policy.Spec.DesiredState,
 		policy.Spec,
 		nmstateapi.NewState(currentState),
@@ -359,7 +359,6 @@ func (r *NodeNetworkConfigurationPolicyReconciler) fillInEnactmentStatus(
 		nmstateapi.EnactmentKey(nodeName, policy.Name),
 		func(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus) {
 			status.DesiredState = desiredStateWithDefaults
-			status.DesiredStateMetaInfo = desiredStateMetaInfo
 			status.CapturedStates = capturedStates
 			status.PolicyGeneration = policy.Generation
 		},

--- a/docs/examples/lldp.yaml
+++ b/docs/examples/lldp.yaml
@@ -1,11 +1,11 @@
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: lldp-enabled-on-eths
+  name: enable-lldp-ethernets-up
 spec:
   capture:
     ethernets: interfaces.type=="ethernet"
     ethernets-up: capture.ethernets | interfaces.state=="up"
-    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=false
+    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=true
   desiredState:
     interfaces: "{{ capture.ethernets-lldp.interfaces }}"

--- a/docs/examples/lldp.yaml
+++ b/docs/examples/lldp.yaml
@@ -1,0 +1,11 @@
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: lldp-enabled-on-eths
+spec:
+  capture:
+    ethernets: interfaces.type=="ethernet"
+    ethernets-up: capture.ethernets | interfaces.state=="up"
+    ethernets-lldp: capture.ethernets-up | interfaces.lldp.enabled:=false
+  desiredState:
+    interfaces: "{{ capture.ethernets-lldp.interfaces }}"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/flock v0.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
-	github.com/nmstate/nmpolicy v0.3.0
+	github.com/nmstate/nmpolicy v0.5.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/cluster-network-operator v0.0.0-20200922032245-f47200e8dbc0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gofrs/flock v0.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nmstate/kubernetes-nmstate/api v0.0.0
-	github.com/nmstate/nmpolicy v0.2.1
+	github.com/nmstate/nmpolicy v0.3.0
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/cluster-network-operator v0.0.0-20200922032245-f47200e8dbc0

--- a/go.sum
+++ b/go.sum
@@ -1223,6 +1223,8 @@ github.com/nmstate/nmpolicy v0.2.1/go.mod h1:uItjRVdUUTrtIUmG/772gMujJwMTHgUxPkU
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
 github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+github.com/nmstate/nmpolicy v0.3.0 h1:mxFDsq6BsWQjPvXa7Yqy2cWyyUgnZpYen6THmiCZ5gE=
+github.com/nmstate/nmpolicy v0.3.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -1225,6 +1225,8 @@ github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8Q
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nmstate/nmpolicy v0.3.0 h1:mxFDsq6BsWQjPvXa7Yqy2cWyyUgnZpYen6THmiCZ5gE=
 github.com/nmstate/nmpolicy v0.3.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
+github.com/nmstate/nmpolicy v0.5.0 h1:xrioHeIq+oSOzJIaYNK/rWEJb9qWwGYeWOF30/DTvPM=
+github.com/nmstate/nmpolicy v0.5.0/go.mod h1:jXA9IOzfrcVDqu08Q1e8M4JbhNDuFxU1MvjwOy4JZ80=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -35,7 +35,8 @@ if oc get ns openshift-ovn-kubernetes &> /dev/null; then
 with ping fail|\
 when connectivity to default gw is lost after state configuration|\
 when name servers are lost after state configuration|\
-when name servers are wrong after state configuration"
+when name servers are wrong after state configuration|\
+LLDP configuration with nmpolicy"
 elif oc get ns openshift-sdn &> /dev/null; then
     SKIPPED_TESTS+="|should discard disarranged parts of the message and keep desired parts of the message"
 fi

--- a/pkg/nmpolicy/generate.go
+++ b/pkg/nmpolicy/generate.go
@@ -50,7 +50,6 @@ func GenerateState(desiredState nmstateapi.State,
 	currentState nmstateapi.State,
 	cachedState map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState) (
 	map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState, /* resolved captures */
-	nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo,
 	nmstateapi.State, /* updated desired state */
 	error) {
 	return GenerateStateWithStateGenerator(GenerateStateWithNMPolicy{}, desiredState, policySpec, currentState, cachedState)
@@ -63,7 +62,6 @@ func GenerateStateWithStateGenerator(stateGenerator NMPolicyGenerator,
 	currentState nmstateapi.State,
 	cachedState map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState) (
 	map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState,
-	nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo,
 	nmstateapi.State, error) {
 	nmpolicySpec := nmpolicytypes.PolicySpec{
 		Capture:      policySpec.Capture,
@@ -76,18 +74,15 @@ func GenerateStateWithStateGenerator(stateGenerator NMPolicyGenerator,
 	)
 	if err != nil {
 		return map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{},
-			nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{},
 			nmstateapi.State{}, err
 	}
 
-	capturedStates, desiredStateMetaInfo, desiredState := convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState)
-	return capturedStates, desiredStateMetaInfo, desiredState, nil
+	capturedStates, desiredState := convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState)
+	return capturedStates, desiredState, nil
 }
 
 func convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState nmpolicytypes.GeneratedState) (
-	map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState,
-	nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo, nmstateapi.State) {
-	desireStateMetaInfo := convertMetaInfoToEnactment(nmpolicyGeneratedState.MetaInfo)
+	map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState, nmstateapi.State) {
 	capturedStates := map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{}
 
 	for captureKey, capturedState := range nmpolicyGeneratedState.Cache.Capture {
@@ -99,7 +94,7 @@ func convertGeneratedStateToEnactmentConfig(nmpolicyGeneratedState nmpolicytypes
 		}
 		capturedStates[captureKey] = capturedState
 	}
-	return capturedStates, desireStateMetaInfo, nmstateapi.State{Raw: []byte(nmpolicyGeneratedState.DesiredState)}
+	return capturedStates, nmstateapi.State{Raw: []byte(nmpolicyGeneratedState.DesiredState)}
 }
 
 func convertCachedStateFromEnactment(

--- a/pkg/nmpolicy/generate_test.go
+++ b/pkg/nmpolicy/generate_test.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("NMPolicy GenerateState", func() {
 	When("fails", func() {
 		It("Should return an error", func() {
-			capturedState, desiredStateMetaInfo, desiredState, err := GenerateStateWithStateGenerator(
+			capturedState, desiredState, err := GenerateStateWithStateGenerator(
 				nmpolicyStub{shouldFail: true},
 				nmstateapi.State{},
 				nmstateapi.NodeNetworkConfigurationPolicySpec{},
@@ -42,7 +42,6 @@ var _ = Describe("NMPolicy GenerateState", func() {
 			)
 			Expect(err).To(HaveOccurred())
 			Expect(capturedState).To(Equal(map[string]nmstateapi.NodeNetworkConfigurationEnactmentCapturedState{}))
-			Expect(desiredStateMetaInfo).To(Equal(nmstateapi.NodeNetworkConfigurationEnactmentMetaInfo{}))
 			Expect(desiredState).To(Equal(nmstateapi.State{}))
 		})
 
@@ -61,7 +60,6 @@ var _ = Describe("NMPolicy GenerateState", func() {
 		}
 
 		generatedState := nmpolicytypes.GeneratedState{
-			MetaInfo:     nmpolicyMetaInfo,
 			DesiredState: []byte(desiredStateYaml),
 			Cache: nmpolicytypes.CachedState{
 				Capture: map[string]nmpolicytypes.CaptureState{
@@ -71,7 +69,7 @@ var _ = Describe("NMPolicy GenerateState", func() {
 			},
 		}
 
-		capturedStates, desiredStateMetaInfo, desiredState, err := GenerateStateWithStateGenerator(
+		capturedStates, desiredState, err := GenerateStateWithStateGenerator(
 			nmpolicyStub{output: generatedState},
 			nmstateapi.State{},
 			nmstateapi.NodeNetworkConfigurationPolicySpec{},
@@ -92,7 +90,6 @@ var _ = Describe("NMPolicy GenerateState", func() {
 		}
 
 		Expect(capturedStates).To(Equal(expectedcCaptureCache))
-		Expect(desiredStateMetaInfo).To(Equal(expectedMetaInfo))
 		Expect(desiredState).To(Equal(nmstateapi.State{Raw: []byte(desiredStateYaml)}))
 	})
 })

--- a/test/doc/examples.go
+++ b/test/doc/examples.go
@@ -29,14 +29,22 @@ type ExampleSpec struct {
 	CleanupState *nmstate.State
 }
 
+//nolint: funlen
 func ExampleSpecs() []ExampleSpec {
 	cleanDNSDesiredState := nmstate.NewState(`dns-resolver:
-    config:
-      search: []
-      server: []
+  config:
+    search: []
+    server: []
 interfaces:
 - name: eth1
   state: absent
+`)
+
+	cleanLLDPDesiredState := nmstate.NewState(`interfaces:
+- name: eth0
+  type: ethernet
+  lldp:
+    enabled: false
 `)
 	return []ExampleSpec{
 		{
@@ -117,6 +125,13 @@ interfaces:
 			PolicyName:   "dns",
 			IfaceNames:   []string{},
 			CleanupState: &cleanDNSDesiredState,
+		},
+		{
+			Name:         "LLDP",
+			FileName:     "lldp.yaml",
+			PolicyName:   "enable-lldp-ethernets-up",
+			IfaceNames:   []string{},
+			CleanupState: &cleanLLDPDesiredState,
 		},
 		{
 			Name:       "Worker selector",

--- a/test/e2e/handler/lldp_with_nmpolicy_test.go
+++ b/test/e2e/handler/lldp_with_nmpolicy_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+	"time"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+	"github.com/nmstate/kubernetes-nmstate/test/e2e/policy"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LLDP configuration with nmpolicy", func() {
+	lldpEnabledPolicyName := "lldp-enabled"
+	lldpDisabledPolicyName := "lldp-disabled"
+
+	configureLldpOnEthernetsCapture := func(enabled string) map[string]string {
+		return map[string]string{
+			"ethernets":      `interfaces.type=="ethernet"`,
+			"ethernets-up":   `capture.ethernets | interfaces.state=="up"`,
+			"ethernets-lldp": fmt.Sprintf(`capture.ethernets-up | interfaces.lldp.enabled:=%s`, enabled),
+		}
+	}
+
+	interfacesWithLldpEnabledState := nmstate.NewState(`interfaces: "{{ capture.ethernets-lldp.interfaces }}"`)
+
+	BeforeEach(func() {
+		By("Enabling LLDP on up ethernet interfaces")
+		setDesiredStateWithPolicyAndCapture(lldpEnabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("true"))
+		policy.WaitForAvailablePolicy(lldpEnabledPolicyName)
+
+		DeferCleanup(func() {
+			deletePolicy(lldpEnabledPolicyName)
+
+			By("Disabling LLDP on up ethernet interfaces")
+			setDesiredStateWithPolicyAndCapture(lldpDisabledPolicyName, interfacesWithLldpEnabledState, configureLldpOnEthernetsCapture("false"))
+			policy.WaitForAvailablePolicy(lldpDisabledPolicyName)
+			deletePolicy(lldpDisabledPolicyName)
+		})
+	})
+
+	It("should enable LLDP on all ethernet interfaces that are up", func() {
+		Byf("Check %s has lldp enabled", primaryNic)
+		for _, node := range nodes {
+			Eventually(
+				func() string {
+					return lldpEnabled(node, primaryNic)
+				},
+				30*time.Second, 1*time.Second,
+			).Should(Equal("true"), fmt.Sprintf("Interface %s should have enabled lldp", primaryNic))
+		}
+	})
+})

--- a/test/e2e/handler/utils.go
+++ b/test/e2e/handler/utils.go
@@ -580,6 +580,11 @@ func nodeInterfacesState(node string, exclude []string) []byte {
 	return ret
 }
 
+func lldpEnabled(node, iface string) string {
+	path := fmt.Sprintf("interfaces.#(name==\"%s\").lldp.enabled", iface)
+	return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()
+}
+
 func ipv4Address(node, iface string) string {
 	path := fmt.Sprintf("interfaces.#(name==\"%s\").ipv4.address.0.ip", iface)
 	return gjson.ParseBytes(currentStateJSON(node)).Get(path).String()

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Upgrade", func() {
 			Context(example.Name, func() {
 				It("should succeed applying the policy", func() {
 					//TODO: remove when no longer required
-					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns"} {
+					for _, policyToSkip := range []string{"vlan", "linux-bridge-vlan", "dns", "enable-lldp-ethernets-up"} {
 						if policyToSkip == example.PolicyName {
 							Skip("Skipping due to malformed example manifest")
 						}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/ast/types.go
@@ -28,6 +28,7 @@ type Terminal struct {
 	Str      *string `json:"string,omitempty"`
 	Identity *string `json:"identity,omitempty"`
 	Number   *int    `json:"number,omitempty"`
+	Boolean  *bool   `json:"boolean,omitempty"`
 }
 
 type Node struct {
@@ -60,6 +61,9 @@ func (t Terminal) String() string {
 	}
 	if t.Number != nil {
 		return fmt.Sprintf("Number=%d", *t.Number)
+	}
+	if t.Boolean != nil {
+		return fmt.Sprintf("Boolean=%t", *t.Boolean)
 	}
 	return ""
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/rune.go
@@ -62,3 +62,7 @@ func (l *lexer) isPlus() bool {
 func (l *lexer) isPipe() bool {
 	return l.scn.Rune() == '|'
 }
+
+func (l *lexer) isDelimiter() bool {
+	return l.isEOF() || l.isSpace() || l.isDot() || l.isEqual() || l.isColon() || l.isPlus() || l.isPipe()
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/lexer/token.go
@@ -23,6 +23,7 @@ const (
 	IDENTITY
 	NUMBER
 	STRING
+	BOOLEAN
 
 	DOT // .
 
@@ -32,9 +33,6 @@ const (
 	EQFILTER // ==
 	MERGE    // +
 	operatorsEnd
-
-	TRUE  // true
-	FALSE // false
 )
 
 var tokens = []string{
@@ -42,6 +40,7 @@ var tokens = []string{
 	IDENTITY: "IDENTITY",
 	NUMBER:   "NUMBER",
 	STRING:   "STRING",
+	BOOLEAN:  "BOOLEAN",
 
 	DOT:  "DOT",
 	PIPE: "PIPE",
@@ -49,9 +48,6 @@ var tokens = []string{
 	REPLACE:  "REPLACE",
 	EQFILTER: "EQFILTER",
 	MERGE:    "MERGE",
-
-	TRUE:  "TRUE",
-	FALSE: "FALSE",
 }
 
 func (t TokenType) String() string {
@@ -66,4 +62,12 @@ type Token struct {
 	Position int
 	Type     TokenType
 	Literal  string
+}
+
+func (t *Token) IsTrue() bool {
+	return t.Literal == "true"
+}
+
+func (t *Token) IsFalse() bool {
+	return t.Literal == "false"
 }

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/operations.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/operations.go
@@ -26,7 +26,6 @@ import (
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/parser"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/resolver"
 	"github.com/nmstate/nmpolicy/nmpolicy/internal/types"
-	nmpolicytypes "github.com/nmstate/nmpolicy/nmpolicy/types"
 )
 
 func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cachedState types.CachedState) (types.GeneratedState, error) {
@@ -55,22 +54,19 @@ func GenerateState(policySpec types.PolicySpec, currentState types.NMState, cach
 		}
 	}
 
-	timestamp := time.Now().UTC()
-	timestampCapturesState(capturedStates, timestamp)
+	stampCapturedStates(capturedStates)
 	return types.GeneratedState{
 		Cache:        types.CachedState{CapturedStates: capturedStates},
 		DesiredState: desiredState,
-		MetaInfo: nmpolicytypes.MetaInfo{
-			Version:   "0",
-			TimeStamp: timestamp,
-		},
 	}, nil
 }
 
-func timestampCapturesState(capturedStates types.CapturedStates, timeStamp time.Time) {
+func stampCapturedStates(capturedStates types.CapturedStates) {
+	now := time.Now().UTC()
 	for captureID, capturedState := range capturedStates {
 		if capturedState.MetaInfo.TimeStamp.IsZero() {
-			capturedState.MetaInfo.TimeStamp = timeStamp
+			capturedState.MetaInfo.TimeStamp = now
+			capturedState.MetaInfo.Version = "0"
 			capturedStates[captureID] = capturedState
 		}
 	}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/replace.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/replace.go
@@ -61,7 +61,7 @@ func (r replaceOpVisitor) visitMap(p path, mapToVisit map[string]interface{}) (i
 	}
 	interfaceToVisit, ok := mapToVisit[*p.currentStep.Identity]
 	if !ok {
-		return nil, nil
+		interfaceToVisit = map[string]interface{}{}
 	}
 
 	visitResult, err := visitState(p.nextStep(), interfaceToVisit, &r)

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/resolver.go
@@ -159,7 +159,7 @@ func (r *resolver) resolveTernaryOperator(operator *ast.TernaryOperator,
 		return nil, err
 	}
 	r.currentNode = &(*operator)[2]
-	value, err := r.resolveStringOrCaptureEntryPath()
+	value, err := r.resolveTerminalOrCapturePath()
 	if err != nil {
 		return nil, err
 	}
@@ -193,11 +193,13 @@ func (r *resolver) resolveInputSource() (types.NMState, error) {
 	return nil, fmt.Errorf("invalid input source (%s), only current state or capture reference is supported", *r.currentNode)
 }
 
-func (r *resolver) resolveStringOrCaptureEntryPath() (interface{}, error) {
+func (r *resolver) resolveTerminalOrCapturePath() (interface{}, error) {
 	if r.currentNode.Str != nil {
 		return *r.currentNode.Str, nil
 	} else if r.currentNode.Path != nil {
 		return r.resolveCaptureEntryPath()
+	} else if r.currentNode.Boolean != nil {
+		return *r.currentNode.Boolean, nil
 	} else {
 		return nil, fmt.Errorf("not supported value. Only string or capture entry path are supported")
 	}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/visitor.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/visitor.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+type stateVisitor interface {
+	visitLastMap(path, map[string]interface{}) (interface{}, error)
+	visitLastSlice(path, []interface{}) (interface{}, error)
+	visitMap(path, map[string]interface{}) (interface{}, error)
+	visitSlice(path, []interface{}) (interface{}, error)
+}
+
+func visitState(p path, inputState interface{}, v stateVisitor) (interface{}, error) {
+	originalMap, isMap := inputState.(map[string]interface{})
+	if isMap {
+		if p.hasMoreSteps() {
+			if p.currentStep.Identity == nil {
+				return nil, pathError(p.currentStep, "unexpected non identity step for map state '%+v'", originalMap)
+			}
+			return v.visitMap(p, originalMap)
+		}
+		return v.visitLastMap(p, originalMap)
+	}
+
+	originalSlice, isSlice := inputState.([]interface{})
+	if isSlice {
+		if p.hasMoreSteps() {
+			return v.visitSlice(p, originalSlice)
+		}
+		return v.visitLastSlice(p, originalSlice)
+	}
+	return nil, pathError(p.currentStep, "invalid type %T for identity step '%v'", inputState, *p.currentStep)
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/walk.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/resolver/walk.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 NMPolicy Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolver
+
+import (
+	"fmt"
+
+	"github.com/nmstate/nmpolicy/nmpolicy/internal/ast"
+)
+
+func walk(inputState map[string]interface{}, pathSteps ast.VariadicOperator) (interface{}, error) {
+	visitResult, err := visitState(newPath(pathSteps), inputState, &walkOpVisitor{})
+	if err != nil {
+		return nil, fmt.Errorf("failed walking path: %w", err)
+	}
+
+	return visitResult, nil
+}
+
+type walkOpVisitor struct{}
+
+func (walkOpVisitor) visitLastMap(p path, mapToAccess map[string]interface{}) (interface{}, error) {
+	return accessMapWithCurrentStep(p, mapToAccess)
+}
+
+func (walkOpVisitor) visitLastSlice(p path, sliceToAccess []interface{}) (interface{}, error) {
+	return accessSliceWithCurrentStep(p, sliceToAccess)
+}
+
+func (w walkOpVisitor) visitSlice(p path, sliceToVisit []interface{}) (interface{}, error) {
+	interfaceToVisit, err := accessSliceWithCurrentStep(p, sliceToVisit)
+	if err != nil {
+		return nil, err
+	}
+	return visitState(p.nextStep(), interfaceToVisit, &w)
+}
+
+func (w walkOpVisitor) visitMap(p path, mapToVisit map[string]interface{}) (interface{}, error) {
+	interfaceToVisit, err := accessMapWithCurrentStep(p, mapToVisit)
+	if err != nil {
+		return nil, err
+	}
+	return visitState(p.nextStep(), interfaceToVisit, &w)
+}
+
+func accessMapWithCurrentStep(p path, mapToAccess map[string]interface{}) (interface{}, error) {
+	if p.currentStep.Identity == nil {
+		return nil, pathError(p.currentStep, "unexpected non identity step for smap state '%+v'", mapToAccess)
+	}
+	v, ok := mapToAccess[*p.currentStep.Identity]
+	if !ok {
+		return nil, pathError(p.currentStep, "step not found at map state '%+v'", mapToAccess)
+	}
+	return v, nil
+}
+
+func accessSliceWithCurrentStep(p path, sliceToAccess []interface{}) (interface{}, error) {
+	if p.currentStep.Number == nil {
+		return nil, pathError(p.currentStep, "unexpected non numeric step for slice state '%+v'", sliceToAccess)
+	}
+	if len(sliceToAccess) <= *p.currentStep.Number {
+		return nil, pathError(p.currentStep, "step not found at slice state '%+v'", sliceToAccess)
+	}
+	return sliceToAccess[*p.currentStep.Number], nil
+}

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/types/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/internal/types/types.go
@@ -38,7 +38,6 @@ type CachedState struct {
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     nmpolicytypes.MetaInfo
 }
 
 type CapturedState struct {

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/operations.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/operations.go
@@ -42,15 +42,15 @@ func GenerateState(policySpec types.PolicySpec,
 	currentState []byte, cachedState types.CachedState) (generatedState types.GeneratedState, err error) {
 	internalPolicySpec, err := toInternalPolicySpec(policySpec)
 	if err != nil {
-		return generatedState, err
+		return generatedState, fmt.Errorf("failed converting to internal policy spec: %v", err)
 	}
 	internalCurrentState, err := toInternalNMState(currentState)
 	if err != nil {
-		return generatedState, err
+		return generatedState, fmt.Errorf("failed converting to internal current state: %v", err)
 	}
 	internalCachedState, err := toInternalCachedState(cachedState)
 	if err != nil {
-		return generatedState, err
+		return generatedState, fmt.Errorf("failed converting to internal cached state: %v", err)
 	}
 
 	internalGeneratedState, err := internal.GenerateState(internalPolicySpec, internalCurrentState, internalCachedState)
@@ -158,7 +158,6 @@ func toGeneratedState(internalGeneratedState internaltypes.GeneratedState) (type
 		return types.GeneratedState{}, err
 	}
 	return types.GeneratedState{
-		MetaInfo:     internalGeneratedState.MetaInfo,
 		DesiredState: desiredState,
 		Cache:        cachedState,
 	}, nil

--- a/vendor/github.com/nmstate/nmpolicy/nmpolicy/types/types.go
+++ b/vendor/github.com/nmstate/nmpolicy/nmpolicy/types/types.go
@@ -16,7 +16,9 @@
 
 package types
 
-import "time"
+import (
+	"time"
+)
 
 type NMState []byte
 
@@ -32,7 +34,6 @@ type CachedState struct {
 type GeneratedState struct {
 	Cache        CachedState
 	DesiredState NMState
-	MetaInfo     MetaInfo
 }
 
 type CaptureState struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -593,7 +593,7 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
-# github.com/nmstate/nmpolicy v0.3.0
+# github.com/nmstate/nmpolicy v0.5.0
 ## explicit; go 1.17
 github.com/nmstate/nmpolicy/nmpolicy
 github.com/nmstate/nmpolicy/nmpolicy/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -593,8 +593,8 @@ github.com/nmstate/kubernetes-nmstate/api/shared
 github.com/nmstate/kubernetes-nmstate/api/v1
 github.com/nmstate/kubernetes-nmstate/api/v1alpha1
 github.com/nmstate/kubernetes-nmstate/api/v1beta1
-# github.com/nmstate/nmpolicy v0.2.1
-## explicit; go 1.16
+# github.com/nmstate/nmpolicy v0.3.0
+## explicit; go 1.17
 github.com/nmstate/nmpolicy/nmpolicy
 github.com/nmstate/nmpolicy/nmpolicy/internal
 github.com/nmstate/nmpolicy/nmpolicy/internal/ast


### PR DESCRIPTION
Backport of 
* [Add test exercising lldp configuration with nmpolicy](https://github.com/nmstate/kubernetes-nmstate/pull/1119)	
* [e2e,doc: Add LLDP example](https://github.com/nmstate/kubernetes-nmstate/pull/1122)

to fix [OCPBUGS-2925](https://issues.redhat.com/browse/OCPBUGS-2925)

Had to pick 6328502a45ef051bd975623ec3b6aceef007cf04 too, as the other commits depend on it