### PR TITLE
add ipv4 example to the interfaces in the alm-examples

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,15 +6,10 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kubernetes-nmstate-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.21.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
-# Labels for testing.
-LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
-LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
-
 # Copy files to locations specified by labels.
-COPY bundle/manifests /manifests/
-COPY bundle/metadata /metadata/
-COPY bundle/tests/scorecard /tests/scorecard/
+COPY ./bundle/manifests /manifests/
+COPY ./bundle/metadata /metadata/

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -53,6 +53,28 @@ metadata:
                   "name": "br1",
                   "state": "up",
                   "type": "linux-bridge"
+                },
+                {
+                  "bridge": {
+                    "options": {
+                      "stp": {
+                        "enabled": false
+                      }
+                    },
+                    "port": [
+                      {
+                        "name": "eth3"
+                      }
+                    ]
+                  },
+                  "ipv4": {
+                    "auto-dns": false,
+                    "dhcp": true,
+                    "enabled": true
+                  },
+                  "name": "br3",
+                  "state": "up",
+                  "type": "linux-bridge"
                 }
               ]
             }
@@ -67,7 +89,7 @@ metadata:
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
-    operators.operatorframework.io/builder: operator-sdk-v1.21.0
+    operators.operatorframework.io/builder: operator-sdk-v1.22.2
     operators.operatorframework.io/internal-objects: '["nodenetworkconfigurationenactments.nmstate.io",
       "nodenetworkstates.nmstate.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,10 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kubernetes-nmstate-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.21.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
-
-  # Annotations for testing.
-  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
-  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/deploy/examples/nmstate.io_v1_nodenetworkconfigurationpolicy_cr.yaml
+++ b/deploy/examples/nmstate.io_v1_nodenetworkconfigurationpolicy_cr.yaml
@@ -23,3 +23,16 @@ spec:
             enabled: false
         port:
           - name: eth2
+    - name: br3
+      type: linux-bridge
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+        auto-dns: false
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: eth3

--- a/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -53,6 +53,28 @@ metadata:
                   "name": "br1",
                   "state": "up",
                   "type": "linux-bridge"
+                },
+                {
+                  "bridge": {
+                    "options": {
+                      "stp": {
+                        "enabled": false
+                      }
+                    },
+                    "port": [
+                      {
+                        "name": "eth3"
+                      }
+                    ]
+                  },
+                  "ipv4": {
+                    "auto-dns": false,
+                    "dhcp": true,
+                    "enabled": true
+                  },
+                  "name": "br3",
+                  "state": "up",
+                  "type": "linux-bridge"
                 }
               ]
             }


### PR DESCRIPTION
  - added the ipv4 example for NodeNetworkConfigurationPolicy interface in bundle csv
  - replicate the change in the manifests directory for ART

Signed-off-by: Nishant Parekh <nparekh@redhat.com>
Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>

Is this a BUG FIX or a FEATURE ?:

Uncomment only one, leave it on its own line:
/kind bug

/kind enhancement
What this PR does / why we need it:

added the ipv4 example for NodeNetworkConfigurationPolicy interface in bundle csv
replicate the change in the manifests directory for ART
This change is trying to address the following CVP issue:
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/ose-kubernetes-nmstate-operator-bundle-container-v4.12.0.202211110827.p0.gfdb8d6d.assembly.stream-1/60cc6e9d-11ae-49e6-8411-4ec0e4eab03f/operator-metadata-linting-bundle-image-output.txt
Special notes for your reviewer:

Release note: