### PR TITLE
4.12: remove alm-examples from manifest

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -2,63 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: |-
-      [
-        {
-          "apiVersion": "nmstate.io/v1",
-          "kind": "NMState",
-          "metadata": {
-            "name": "nmstate"
-          }
-        },
-        {
-          "apiVersion": "nmstate.io/v1",
-          "kind": "NodeNetworkConfigurationPolicy",
-          "metadata": {
-            "name": "example-nodenetworkconfigurationpolicy"
-          },
-          "spec": {
-            "desiredState": {
-              "interfaces": [
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth1"
-                      }
-                    ]
-                  },
-                  "name": "br0",
-                  "state": "up",
-                  "type": "linux-bridge"
-                },
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth2"
-                      }
-                    ]
-                  },
-                  "name": "br1",
-                  "state": "up",
-                  "type": "linux-bridge"
-                }
-              ]
-            }
-          }
-        }
-      ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"

--- a/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -2,63 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: |-
-      [
-        {
-          "apiVersion": "nmstate.io/v1",
-          "kind": "NMState",
-          "metadata": {
-            "name": "nmstate"
-          }
-        },
-        {
-          "apiVersion": "nmstate.io/v1",
-          "kind": "NodeNetworkConfigurationPolicy",
-          "metadata": {
-            "name": "example-nodenetworkconfigurationpolicy"
-          },
-          "spec": {
-            "desiredState": {
-              "interfaces": [
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth1"
-                      }
-                    ]
-                  },
-                  "name": "br0",
-                  "state": "up",
-                  "type": "linux-bridge"
-                },
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth2"
-                      }
-                    ]
-                  },
-                  "name": "br1",
-                  "state": "up",
-                  "type": "linux-bridge"
-                }
-              ]
-            }
-          }
-        }
-      ]
     capabilities: Basic Install
     categories: OpenShift Optional
     certified: "false"


### PR DESCRIPTION
avoid CI error: "NodeNetworkConfigurationPolicy: example must have a provided API"

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>
