### PR TITLE
OCPBUGS-5124: Add empty spec to NMState CR example

### DIFF
--- a/deploy/examples/nmstate.io_v1_nmstate_cr.yaml
+++ b/deploy/examples/nmstate.io_v1_nmstate_cr.yaml
@@ -2,3 +2,4 @@ apiVersion: nmstate.io/v1
 kind: NMState
 metadata:
   name: nmstate
+spec: {}

--- a/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/4.12/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -9,7 +9,8 @@ metadata:
           "kind": "NMState",
           "metadata": {
             "name": "nmstate"
-          }
+          },
+          "spec": {}
         }
       ]
     capabilities: Basic Install

--- a/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -8,7 +8,8 @@ metadata:
         "kind": "NMState",
         "metadata": {
           "name": "nmstate"
-        }
+        },
+        "spec": {}
       }]
     operatorframework.io/suggested-namespace: openshift-nmstate
     operators.openshift.io/infrastructure-features: '["disconnected"]'


### PR DESCRIPTION
The CVP tests are unhappy with the missing spec field, and although we don't actually need or want one let's provide something to make the check happy.

Note that the spec on NMState is largely used to control pod placement, and the default behavior is what will be wanted in the majority of cases. Setting any value on this object may result in undesirable behavior.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
