### PR TITLE
OPNET-261: Integrate the ART build of nmstate-console-plugin image in the manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ OPERATOR_IMAGE_TAG ?= latest
 OPERATOR_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_FULL_NAME)
 
+PLUGIN_IMAGE_NAME ?= nmstate-console-plugin
+PLUGIN_IMAGE_TAG ?= latest
+PLUGIN_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(PLUGIN_IMAGE_NAME):$(PLUGIN_IMAGE_TAG)
+PLUGIN_IMAGE ?= $(IMAGE_REGISTRY)/$(PLUGIN_IMAGE_FULL_NAME)
+
 export HANDLER_NAMESPACE ?= nmstate
 export OPERATOR_NAMESPACE ?= $(HANDLER_NAMESPACE)
 HANDLER_PULL_POLICY ?= Always
@@ -155,7 +160,7 @@ check-ocp-bundle: ocp-update-bundle-manifests
 generate: gen-k8s gen-crds gen-rbac
 
 manifests:
-	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
+	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -plugin-image=$(PLUGIN_IMAGE) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: SKIP_PUSH=true
 handler: push-handler

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -74,6 +74,8 @@ spec:
               value: ""
             - name: HANDLER_IMAGE
               value: {{ .HandlerImage }}
+            - name: PLUGIN_IMAGE
+              value: {{ .PluginImage }}
             - name: HANDLER_IMAGE_PULL_POLICY
               value: {{ .HandlerPullPolicy }}
             - name: HANDLER_NAMESPACE

--- a/hack/ocp-build-and-deploy-bundle.sh
+++ b/hack/ocp-build-and-deploy-bundle.sh
@@ -10,6 +10,8 @@
 #   - HANDLER_IMAGE_TAG (defaults to ${CHANNEL})
 #   - OPERATOR_IMAGE_NAME (defaults to origin-kubernetes-nmstate-operator)
 #   - OPERATOR_IMAGE_TAG (defaults to ${CHANNEL})
+#   - PLUGIN_IMAGE_NAME (defaults to origin-nmstate-console-plugin)
+#   - PLUGIN_IMAGE_TAG (defaults to ${CHANNEL})
 #   - CHANNEL (defaults to the latest 4.x version in manifests/)
 #   - VERSION (defaults to ${CHANNEL}.0)
 #   - BUNDLE_VERSION (defaults to ${VERSION})

--- a/hack/ocp-bundle-common.sh
+++ b/hack/ocp-bundle-common.sh
@@ -45,6 +45,10 @@ export OPERATOR_IMAGE_NAME="${OPERATOR_IMAGE_NAME:-origin-kubernetes-nmstate-ope
 export OPERATOR_IMAGE_TAG="${OPERATOR_IMAGE_TAG:-${VERSION_MAJOR_MINOR}}" # TODO(chocobomb) Do we tag as "stable" or still "4.x" ?
 export OPERATOR_NAMESPACE="${NAMESPACE}"
 
+export PLUGIN_IMAGE_NAME="${PLUGIN_IMAGE_NAME:-origin-nmstate-console-plugin}"
+export PLUGIN_IMAGE_TAG="${PLUGIN_IMAGE_TAG:-${VERSION_MAJOR_MINOR}}" # TODO(chocobomb) Do we tag as "stable" or still "4.x" ?
+export PLUGIN_NAMESPACE="${NAMESPACE}"
+
 export BUNDLE_VERSION="${BUNDLE_VERSION:-${VERSION_MAJOR_MINOR}}" # TODO(chocobomb) X.Y or X.Y.Z here? Is this variable even used?
 export BUNDLE_IMG="${BUNDLE_IMG:-${IMAGE_REGISTRY}/${IMAGE_REPO}/kubernetes-nmstate-operator-bundle:${BUNDLE_VERSION}}" # TODO(chocobomb) Is this variable even used?
 

--- a/hack/ocp-update-bundle-manifests.sh
+++ b/hack/ocp-update-bundle-manifests.sh
@@ -14,6 +14,7 @@ rm -rf ${BUNDLE_DIR}/manifests ${BUNDLE_DIR}/metadata
 IMAGE_REPO=${IMAGE_REPO} \
 HANDLER_IMAGE_NAME=${HANDLER_IMAGE_NAME} HANDLER_IMAGE_TAG=${HANDLER_IMAGE_TAG} HANDLER_NAMESPACE=${HANDLER_NAMESPACE} \
 OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME} OPERATOR_IMAGE_TAG=${OPERATOR_IMAGE_TAG} OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE} \
+PLUGIN_IMAGE_NAME=${PLUGIN_IMAGE_NAME} PLUGIN_IMAGE_TAG=${PLUGIN_IMAGE_TAG} PLUGIN_NAMESPACE=${PLUGIN_NAMESPACE} \
 VERSION=${VERSION} CHANNELS=${CHANNEL},alpha DEFAULT_CHANNEL=${CHANNEL} \
 BUNDLE_DIR=${BUNDLE_DIR} MANIFEST_BASES_DIR=${MANIFEST_BASES_DIR} make bundle
 
@@ -43,6 +44,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kubernetes-nmstate-handler:${VERSION_MAJOR_MINOR}
+  - name: nmstate-console-plugin-rhel8
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-nmstate-console-plugin:${VERSION_MAJOR_MINOR}
 EOF
 
 # undo changes on "root" bundle.Dockerfile (gets updated by `make bundle`)

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -41,6 +41,7 @@ func main() {
 		OperatorNamespace  string
 		OperatorImage      string
 		OperatorPullPolicy string
+		PluginImage        string
 	}
 
 	handlerNamespace := flag.String("handler-namespace", "nmstate", "Namespace for the NMState handler")
@@ -50,6 +51,7 @@ func main() {
 	operatorNamespace := flag.String("operator-namespace", "nmstate-operator", "Namespace for the NMState operator")
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
 	operatorPullPolicy := flag.String("operator-pull-policy", "Always", "Pull policy for the NMState operator image")
+	pluginImage := flag.String("plugin-image", "", "Image for the NMState console plugin")
 	inputDir := flag.String("input-dir", "", "Input directory")
 	outputDir := flag.String("output-dir", "", "Output directory")
 	flag.Parse()
@@ -62,6 +64,7 @@ func main() {
 		OperatorNamespace:  *operatorNamespace,
 		OperatorImage:      *operatorImage,
 		OperatorPullPolicy: *operatorPullPolicy,
+		PluginImage:        *pluginImage,
 	}
 
 	// Clean up output dir so we don't have old files.

--- a/manifests/stable/manifests/image-references
+++ b/manifests/stable/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kubernetes-nmstate-handler:4.13
+  - name: nmstate-console-plugin-rhel8
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-nmstate-console-plugin:4.13

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -187,6 +187,8 @@ spec:
                       - name: RUN_OPERATOR
                       - name: HANDLER_IMAGE
                         value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.13
+                      - name: PLUGIN_IMAGE
+                        value: quay.io/openshift/origin-nmstate-console-plugin:4.13
                       - name: HANDLER_IMAGE_PULL_POLICY
                         value: Always
                       - name: HANDLER_NAMESPACE


### PR DESCRIPTION

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
kubernetes-nmstate-operator should deploy the D/S version of the console plugin image, and ART pipeline will replace the upstream image of `quay.io/nmstate/nmstate-console-plugin:release-1.0.0` with its downstream counterpart
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Integrate the ART build of nmstate-console-plugin image in the CSV
```
