### PR TITLE
Revert "[release-4.13] Add UI Plugin manifests to Openshift Dockerfile"

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -13,7 +13,6 @@ COPY deploy/handler/service_account.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/role_binding.yaml /bindata/kubernetes-nmstate/rbac/
 COPY deploy/handler/cluster_role.yaml /bindata/kubernetes-nmstate/rbac/
-COPY deploy/openshift/ui-plugin/ /bindata/kubernetes-nmstate/openshift/ui-plugin/
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/metadata /metadata
 


### PR DESCRIPTION
Reverts openshift/kubernetes-nmstate#352

There are two problems with this:
1) It's not a bug fix and should not have been backported.
2) It's causing us to pull a non-openshift image. I know there's a fix proposed to master for that, but see point 1.