### PR TITLE
UPSTREAM: <carry>: Lower flake attempts to 3

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -17,7 +17,7 @@ export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
 export PRIMARY_NIC=enp2s0
 export FIRST_SECONDARY_NIC=enp3s0
 export SECOND_SECONDARY_NIC=enp4s0
-export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-5}"
+export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-3}"
 
 SKIPPED_TESTS="user-guide|bridged|\
 when desiredState is updated with ovs-bridge with linux bond as port" # https://bugzilla.redhat.com/show_bug.cgi?id=2005240 is not yet fixed in nmstate 1.2

--- a/hack/ocp-e2e-tests-operator.sh
+++ b/hack/ocp-e2e-tests-operator.sh
@@ -14,7 +14,7 @@ export KUBEVIRT_PROVIDER=external
 export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
 export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
 export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
-export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-5}"
+export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-3}"
 
 if [ "${CI}" == "true" ]; then
     source ${SHARED_DIR}/fix-uid.sh


### PR DESCRIPTION
If a test can't pass in 3 attempts we probably shouldn't consider that acceptable anyway, and 5 flakes on some longer tests causes us to exceed the timeout for CI jobs, which means we don't even attempt to run all of the tests.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
