### PR TITLE
[OCPBUGS-16644] Fix nmstate-console-plugin for Single-Stack IPv6 clusters (#1200)

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -316,6 +316,7 @@ func (r *NMStateReconciler) applyOpenshiftUIPlugin(instance *nmstatev1.NMState) 
 	data.Data["PluginNamespace"] = environment.GetEnvVar("HANDLER_NAMESPACE", "openshift-nmstate")
 	data.Data["PluginName"] = environment.GetEnvVar("PLUGIN_NAME", "nmstate-console-plugin")
 	data.Data["PluginImage"] = environment.GetEnvVar("PLUGIN_IMAGE", "quay.io/nmstate/nmstate-console-plugin:release-1.0.0")
+	data.Data["PluginPort"] = environment.GetEnvVar("PLUGIN_PORT", "9443")
 	return r.renderAndApply(instance, data, filepath.Join("openshift", "ui-plugin"), true)
 }
 

--- a/deploy/openshift/ui-plugin/configmap.yaml
+++ b/deploy/openshift/ui-plugin/configmap.yaml
@@ -16,7 +16,7 @@ data:
       default_type       application/octet-stream;
       keepalive_timeout  65;
       server {
-        listen              9443 ssl;
+        listen              [::]:{{ .PluginPort }} ipv6only=off ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
         root                /opt/app-root/src;

--- a/deploy/openshift/ui-plugin/consoleplugin.yaml
+++ b/deploy/openshift/ui-plugin/consoleplugin.yaml
@@ -9,5 +9,5 @@ spec:
   service:
     name: {{ .PluginName }}
     namespace: {{ .PluginNamespace }}
-    port: 9443
+    port: {{ .PluginPort }}
     basePath: '/'

--- a/deploy/openshift/ui-plugin/deployment.yaml
+++ b/deploy/openshift/ui-plugin/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: {{ .PluginName }}
           image: {{ .PluginImage }}
           ports:
-            - containerPort: 9443
+            - containerPort: {{ .PluginPort }}
               protocol: TCP
           imagePullPolicy: Always
           resources:

--- a/deploy/openshift/ui-plugin/service.yaml
+++ b/deploy/openshift/ui-plugin/service.yaml
@@ -12,10 +12,10 @@ metadata:
     app.kubernetes.io/part-of: {{ .PluginName }}
 spec:
   ports:
-    - name: 9443-tcp
+    - name: {{ .PluginPort }}-tcp
       protocol: TCP
-      port: 9443
-      targetPort: 9443
+      port: {{ .PluginPort }}
+      targetPort: {{ .PluginPort }}
   selector:
     app: {{ .PluginName }}
   type: ClusterIP


### PR DESCRIPTION
(cherry-pick of https://github.com/nmstate/kubernetes-nmstate/pull/1200/commits/46506dacd00983cbb938e630f8ba52fed7cec541)
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:
When a single-stack IPv6 cluster is being used, the nginx server isn't listening on IPv6 requests, just IPv4. Changing the nginx configuration `listen` directive to `[::]:9443 ipv6only=off ssl` will accept connections both for IPv6 and IPv4. Also, parametrize the service port.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
fix nmstate-console-plugin in single-stack ipv6 clusters.
```
