### PR TITLE
Use --cert instead of --negotiate in nightly script

### DIFF
--- a/hack/ocp-install-nightly-art-operators.sh
+++ b/hack/ocp-install-nightly-art-operators.sh
@@ -8,6 +8,8 @@
 
 set -eo pipefail
 
+BREW_CERT=${BREW_CERT:-$HOME/brew.pem}
+
 function wait_for_all_nodes_ready() {
   i=20
   while [ $i -gt 0 ]; do
@@ -24,11 +26,11 @@ function wait_for_all_nodes_ready() {
   done
 }	
 
-brew_credentials=$(curl --negotiate -u : https://employee-token-manager.registry.redhat.com/v1/tokens -s) #make sure you created a token before (https://source.redhat.com/groups/public/teamnado/wiki/brew_registry)
+brew_credentials=$(curl --cert $BREW_CERT https://employee-token-manager.registry.redhat.com/v1/tokens -s) #make sure you created a token before (https://source.redhat.com/groups/public/teamnado/wiki/brew_registry)
 if [[ "${brew_credentials}" == "null" ]]; then
   echo "No Brew token found. Trying to create a token..."
   # Brew token does not exist. Create one
-  brew_credentials=$(curl --negotiate -u : -X POST -H 'Content-Type: application/json' --data '{"description":"openshift 4 testing"}' https://employee-token-manager.registry.redhat.com/v1/tokens -s)
+  brew_credentials=$(curl --cert $BREW_CERT -X POST -H 'Content-Type: application/json' --data '{"description":"openshift 4 testing"}' https://employee-token-manager.registry.redhat.com/v1/tokens -s)
   if [[ -z "$brew_credentials" ]] || [[ "$brew_credentials" == "null" ]]; then
     echo "Could not create a Brew token for you. Please visit https://source.redhat.com/groups/public/teamnado/wiki/brew_registry for more information about creating the Brew token manually." 
     exit 1


### PR DESCRIPTION
The --negotiate option is supposed to be going away for the token manager. Use the cert-based method instead.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
