### PR TITLE
UPSTREAM: <ae888af>: probe: Add support for systems without IPv4 gateway

### DIFF
--- a/hack/ocp-update-bundle-manifests.sh
+++ b/hack/ocp-update-bundle-manifests.sh
@@ -18,7 +18,7 @@ function yq4 {
       echo ${INSTALL_DIR}/yq
     else
       # yq is not installed/in wrong version --> install v4
-      GOBIN=$INSTALL_DIR GOFLAGS= go install github.com/mikefarah/yq/v4@latest
+      GOBIN=$INSTALL_DIR GOFLAGS= go install github.com/mikefarah/yq/v4@v4.34.2
       echo ${INSTALL_DIR}/yq
     fi
   fi


### PR DESCRIPTION
The current code assumes that there is always a default gateway using IPv4 stack. Because of this, ping check will never succeed on a system without one, e.g. single-stack IPv6.

This patch changes the behaviour so that we will use either of IPv4 or IPv6 gateways effectively enabling IPv6-only systems.

Cherry-picks: https://github.com/openshift/kubernetes-nmstate/pull/396