### PR TITLE
UPSTREAM: <carry>: Fix CI SSH proxy hack

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -24,7 +24,6 @@ SKIPPED_TESTS="user-guide|bridged|\
 when desiredState is updated with ovs-bridge with linux bond as port" # https://bugzilla.redhat.com/show_bug.cgi?id=2005240 is not yet fixed in nmstate 1.2
 
 if [ "${CI}" == "true" ]; then
-    source ${SHARED_DIR}/fix-uid.sh
     export SSH="./hack/ssh-ci.sh"
 else
     export SSH="./hack/ssh.sh"

--- a/hack/ocp-e2e-tests-operator.sh
+++ b/hack/ocp-e2e-tests-operator.sh
@@ -17,7 +17,6 @@ export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
 export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-3}"
 
 if [ "${CI}" == "true" ]; then
-    source ${SHARED_DIR}/fix-uid.sh
     export SSH=./hack/ssh-ci.sh
 else
     export SSH=./hack/ssh.sh


### PR DESCRIPTION
After moving from Packet to OFCIR we don't need to source UID hacks anymore.