### PR TITLE
[4.12] OCPBUGS-22480: Use correct domain root-servers.net for DNS probes (#1163)

### DIFF
--- a/pkg/probe/probes.go
+++ b/pkg/probe/probes.go
@@ -242,7 +242,7 @@ func runDNS(_ client.Client) (bool, error) {
 				return d.DialContext(ctx, network, net.JoinHostPort(runningNameServer.String(), "53"))
 			},
 		}
-		_, err := r.LookupNS(context.TODO(), "root-server.net")
+		_, err := r.LookupNS(context.TODO(), "root-servers.net")
 		if err != nil {
 			errs = append(errs, err)
 		} else {


### PR DESCRIPTION
Signed-off-by: Andreas Karis <ak.karis@gmail.com>
(cherry picked from commit 1bcf612cc6f0cb4b6ca1f3952988819a03f45c4a)

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
