### PR TITLE
Handle RHEL 9-based images in nmstate-version script

### DIFF
--- a/hack/nmstate-version.py
+++ b/hack/nmstate-version.py
@@ -27,9 +27,12 @@ from requests_kerberos import HTTPKerberosAuth
 import sys
 
 check_version = sys.argv[1]
+rhel_version = 8
+if float(check_version) > 4.13:
+    rhel_version = 9
 
 base_url = 'https://errata.devel.redhat.com'
-start_page = base_url + '/package/show/openshift-kubernetes-nmstate-handler-rhel-8-container'
+start_page = base_url + f'/package/show/openshift-kubernetes-nmstate-handler-rhel-{rhel_version}-container'
 r = requests.get(start_page, auth=HTTPKerberosAuth())
 page = r.text
 version_re = re.compile('title=".* (\d+\.\d+\.\d+) .*".*\n.*\n.*\n.*href="(/release_engineering/show_released_build/\d+)"', flags=re.M)


### PR DESCRIPTION
Since we moved to RHEL 9 in 4.14 for the container images the builds no longer show up on the RHEL 8 page. This adds logic to make sure we look in the right place based on the requested OCP version.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
