### PR TITLE
[4.12] test: use IPv6 link-local DNS server (#1225)

### DIFF
--- a/test/e2e/handler/rollback_test.go
+++ b/test/e2e/handler/rollback_test.go
@@ -76,10 +76,10 @@ func setBadNameServers(nic string) nmstate.State {
   config:
     search: []
     server:
-      - 192.168.100.3
-      - 192.168.100.4
+      - "fe80::deef:1%%%[1]s"
+      - "fe80::deef:2%%%[1]s"
 interfaces:
-- name: %s
+- name: %[1]s
   type: ethernet
   state: up
   ipv4:


### PR DESCRIPTION
This PR changes the test scenario for configuring an incorrect DNS server. Instead of using a fixed `192.x.x.x` name server we are now using an IPv6 link-local address `fe80::deef:1` parametrized with a NIC name.

The reason for this change is the bug in NetworkManager that prevents rollbacks of incorrect DNS servers applied globally, i.e. not on a specific NIC. As this test explicitly tests the rollback functionality, we want it to explicitly configure a specific NIC and not a global configuration.

By using IPv6 link-local address we are ensure the configuration is applied to the NIC specified, what fulfills the requitement of our test.