### PR TITLE
e2e: don't require empty starting state for bridge mappings

### DIFF
--- a/test/e2e/handler/nns_ovn.go
+++ b/test/e2e/handler/nns_ovn.go
@@ -35,10 +35,6 @@ var _ = Describe("[nns] NNS OVN bridge mappings", func() {
 	)
 
 	BeforeEach(func() {
-		for _, node := range nodes {
-			Expect(nodeBridgeMappings(node)).To(BeEmpty())
-		}
-
 		By("provisioning some bridge mappings ...")
 		updateDesiredState(bridgeMappings(networkName, bridgeName))
 
@@ -57,7 +53,7 @@ var _ = Describe("[nns] NNS OVN bridge mappings", func() {
 	It("are listed", func() {
 		for _, node := range nodes {
 			Expect(nodeBridgeMappings(node)).To(
-				ConsistOf(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
+				ContainElement(state.PhysicalNetworks{Name: networkName, Bridge: bridgeName}))
 		}
 	})
 })


### PR DESCRIPTION
This commit changes the behaviour of the OVN bridge mapping test so that we do not require the initial state to be empty. Thanks to this we make e2e tests working correctly on machines whre OVN is already used and bridges are deployed.

Without this change the test will pass only if no OVN bridge mappings exist on the node. The assumption is quite strong and not really desired.