### PR TITLE
OCPBUGS-34643: Fix monitoring for 4.17 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ check-ocp-bundle: ocp-update-bundle-manifests
 generate: gen-k8s gen-crds gen-rbac
 
 manifests:
-	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -kube-rbac-proxy-image=$(KUBE_RBAC_PROXY_IMAGE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -plugin-image=$(PLUGIN_IMAGE) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
+	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -monitoring-namespace=$(MONITORING_NAMESPACE) -kube-rbac-proxy-image=$(KUBE_RBAC_PROXY_IMAGE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -plugin-image=$(PLUGIN_IMAGE) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: SKIP_PUSH=true
 handler: push-handler

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -278,6 +278,8 @@ spec:
                   value: Always
                 - name: HANDLER_NAMESPACE
                   value: nmstate
+                - name: MONITORING_NAMESPACE
+                  value: monitoring
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -299,6 +299,7 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 	data.Data["HandlerImage"] = os.Getenv("HANDLER_IMAGE")
 	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
 	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
+	data.Data["MonitoringNamespace"] = os.Getenv("MONITORING_NAMESPACE")
 	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["InfraNodeSelector"] = archAndCRInfraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -73,14 +73,15 @@ var _ = Describe("NMState controller reconcile", func() {
 				UID:  "12345",
 			},
 		}
-		handlerPrefix      = "handler"
-		handlerNamespace   = "nmstate"
-		handlerKey         = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
-		webhookKey         = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
-		handlerImage       = "quay.io/some_image"
-		kubeRBACProxyImage = "quay.io/some_kube_rbac_proxy_image"
-		imagePullPolicy    = "Always"
-		manifestsDir       = ""
+		handlerPrefix       = "handler"
+		handlerNamespace    = "nmstate"
+		handlerKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-handler"}
+		webhookKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
+		handlerImage        = "quay.io/some_image"
+		monitoringNamespace = "monitoring"
+		kubeRBACProxyImage  = "quay.io/some_kube_rbac_proxy_image"
+		imagePullPolicy     = "Always"
+		manifestsDir        = ""
 	)
 	BeforeEach(func() {
 		var err error
@@ -106,6 +107,7 @@ var _ = Describe("NMState controller reconcile", func() {
 		os.Setenv("HANDLER_IMAGE", handlerImage)
 		os.Setenv("HANDLER_IMAGE_PULL_POLICY", imagePullPolicy)
 		os.Setenv("HANDLER_PREFIX", handlerPrefix)
+		os.Setenv("MONITORING_NAMESPACE", monitoringNamespace)
 		os.Setenv("KUBE_RBAC_PROXY_IMAGE", kubeRBACProxyImage)
 	})
 	AfterEach(func() {

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -511,6 +511,7 @@ metadata:
 spec:
   endpoints:
   - scheme: https
+    port: metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       insecureSkipVerify: true

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -514,9 +514,18 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       insecureSkipVerify: true
+    metricRelabelings:
+      - action: labeldrop
+        regex: instance
+      - action: labeldrop
+        regex: job
     relabelings:
-    - action: labeldrop
-      regex: (instance|pod|container|job|namespace|service)
+      - action: labeldrop
+        regex: pod
+      - action: labeldrop
+        regex: container
+      - action: labeldrop
+        regex: endpoint
   namespaceSelector:
     matchNames:
       - {{ .HandlerNamespace }}

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -523,3 +523,34 @@ spec:
   selector:
     matchLabels:
       prometheus.nmstate.io: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: {{ .HandlerNamespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: {{ .HandlerNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: {{ .MonitoringNamespace }}

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -80,5 +80,7 @@ spec:
               value: {{ .HandlerPullPolicy }}
             - name: HANDLER_NAMESPACE
               value: {{ .HandlerNamespace }}
+            - name: MONITORING_NAMESPACE
+              value: {{ .MonitoringNamespace }}
             - name: KUBE_RBAC_PROXY_IMAGE
               value: {{ .KubeRBACProxyImage }}

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -34,15 +34,16 @@ func exitWithError(err error, cause string, args ...interface{}) {
 
 func main() {
 	type Inventory struct {
-		HandlerNamespace   string
-		HandlerImage       string
-		HandlerPullPolicy  string
-		HandlerPrefix      string
-		OperatorNamespace  string
-		OperatorImage      string
-		OperatorPullPolicy string
-		KubeRBACProxyImage string
-		PluginImage        string
+		HandlerNamespace    string
+		HandlerImage        string
+		HandlerPullPolicy   string
+		HandlerPrefix       string
+		OperatorNamespace   string
+		OperatorImage       string
+		OperatorPullPolicy  string
+		MonitoringNamespace string
+		KubeRBACProxyImage  string
+		PluginImage         string
 	}
 
 	handlerNamespace := flag.String("handler-namespace", "nmstate", "Namespace for the NMState handler")
@@ -52,6 +53,7 @@ func main() {
 	operatorNamespace := flag.String("operator-namespace", "nmstate-operator", "Namespace for the NMState operator")
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
 	operatorPullPolicy := flag.String("operator-pull-policy", "Always", "Pull policy for the NMState operator image")
+	monitoringNamespace := flag.String("monitoring-namespace", "monitoring", "Namespace for the cluster monitoring")
 	kubeRBACProxyImage := flag.String("kube-rbac-proxy-image", "", "Image for the kube RBAC proxy needed for metrics")
 	pluginImage := flag.String("plugin-image", "", "Image for the NMState console plugin")
 	inputDir := flag.String("input-dir", "", "Input directory")
@@ -59,15 +61,16 @@ func main() {
 	flag.Parse()
 
 	inventory := Inventory{
-		HandlerNamespace:   *handlerNamespace,
-		HandlerImage:       *handlerImage,
-		HandlerPullPolicy:  *handlerPullPolicy,
-		HandlerPrefix:      *handlerPrefix,
-		OperatorNamespace:  *operatorNamespace,
-		OperatorImage:      *operatorImage,
-		OperatorPullPolicy: *operatorPullPolicy,
-		KubeRBACProxyImage: *kubeRBACProxyImage,
-		PluginImage:        *pluginImage,
+		HandlerNamespace:    *handlerNamespace,
+		HandlerImage:        *handlerImage,
+		HandlerPullPolicy:   *handlerPullPolicy,
+		HandlerPrefix:       *handlerPrefix,
+		OperatorNamespace:   *operatorNamespace,
+		OperatorImage:       *operatorImage,
+		OperatorPullPolicy:  *operatorPullPolicy,
+		MonitoringNamespace: *monitoringNamespace,
+		KubeRBACProxyImage:  *kubeRBACProxyImage,
+		PluginImage:         *pluginImage,
 	}
 
 	// Clean up output dir so we don't have old files.

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -210,6 +210,8 @@ spec:
                         value: Always
                       - name: HANDLER_NAMESPACE
                         value: openshift-nmstate
+                      - name: MONITORING_NAMESPACE
+                        value: monitoring
                       - name: KUBE_RBAC_PROXY_IMAGE
                         value: quay.io/openshift/origin-kube-rbac-proxy:4.17
                     image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.17


### PR DESCRIPTION
Contains

* 54764880db90bcbb9cee2782126dbc73d1adb7fd
* 5f77ce980103d73b1e8eda14eb1d10add5f65a29
* 8e56abb1fc78d965470ff57b7c3396fb8cae94cb

and runs `make ocp-update-bundle-manifests`