### PR TITLE
OCPBUGS-42222: Revert "openshift, operator: Use cert service at openshift (#1263)"

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -33,10 +33,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/openshift/cluster-network-operator/pkg/apply"
@@ -115,10 +113,6 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if err := r.applyManifests(instance, ctx); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	if err := r.cleanupObsoleteResources(ctx, instance.Namespace); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -315,12 +309,6 @@ func (r *NMStateReconciler) applyHandler(instance *nmstatev1.NMState) error {
 	data.Data["HandlerAffinity"] = handlerAffinity
 	data.Data["SelfSignConfiguration"] = selfSignConfiguration
 
-	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
-	if err != nil {
-		return err
-	}
-	data.Data["IsOpenShift"] = isOpenShift
-
 	return r.renderAndApply(instance, data, "handler", true)
 }
 
@@ -351,26 +339,6 @@ func (r *NMStateReconciler) patchOpenshiftConsolePlugin(ctx context.Context) err
 			r.Log.Error(err, fmt.Sprintf("Could not update resource - APIVersion: %s, Kind: %s, Name: %s",
 				consoleObj.APIVersion, consoleObj.Kind, consoleObj.Name))
 			return err
-		}
-	}
-	return nil
-}
-
-func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context, namespace string) error {
-	isOpenShift, err := cluster.IsOpenShift(r.APIClient)
-	if err != nil {
-		return err
-	}
-	// We are no longer using cert-manager at openshift, let's remove it
-	if isOpenShift {
-		err = r.Client.Delete(ctx, &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
-			},
-		})
-		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed deleting obsolete cert-manager deployment at openshift: %w", err)
 		}
 	}
 	return nil

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -90,7 +90,6 @@ spec:
         - name: tls-key-pair
           secret:
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
-{{- if not .IsOpenShift }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -177,7 +176,6 @@ spec:
               value: {{ .SelfSignConfiguration.CertRotateInterval }}
             - name: CERT_OVERLAP_INTERVAL
               value: {{ .SelfSignConfiguration.CertOverlapInterval }}
-{{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -298,8 +296,6 @@ kind: Service
 metadata:
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}nmstate-webhook
   labels:
     app: kubernetes-nmstate
 spec:
@@ -314,8 +310,6 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{template "handlerPrefix" .}}nmstate
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app: kubernetes-nmstate
 webhooks:

--- a/test/e2e/operator/operator.go
+++ b/test/e2e/operator/operator.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	nmstatev1 "github.com/nmstate/kubernetes-nmstate/api/v1"
-	"github.com/nmstate/kubernetes-nmstate/pkg/cluster"
 	"github.com/nmstate/kubernetes-nmstate/test/cmd"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/daemonset"
 	"github.com/nmstate/kubernetes-nmstate/test/e2e/deployment"
@@ -120,18 +119,14 @@ func EventuallyOperandIsReady(testData TestData) {
 	daemonset.GetEventually(testData.HandlerKey).Should(daemonset.BeReady(), "should start handler daemonset")
 	By("Wait deployment webhook is ready")
 	deployment.GetEventually(testData.WebhookKey).Should(deployment.BeReady(), "should start webhook deployment")
-	if !IsOpenShift() {
-		By("Wait deployment cert-manager is ready")
-		deployment.GetEventually(testData.CertManagerKey).Should(deployment.BeReady(), "should start cert-manager deployment")
-	}
+	By("Wait deployment cert-manager is ready")
+	deployment.GetEventually(testData.CertManagerKey).Should(deployment.BeReady(), "should start cert-manager deployment")
 }
 
 func EventuallyOperandIsNotFound(testData TestData) {
 	EventuallyIsNotFound(testData.HandlerKey, &appsv1.DaemonSet{}, "should delete handler daemonset")
 	EventuallyIsNotFound(testData.WebhookKey, &appsv1.Deployment{}, "should delete webhook deployment")
-	if !IsOpenShift() {
-		EventuallyIsNotFound(testData.CertManagerKey, &appsv1.Deployment{}, "should delete cert-manager deployment")
-	}
+	EventuallyIsNotFound(testData.CertManagerKey, &appsv1.Deployment{}, "should delete cert-manager deployment")
 	By("Wait for operand pods to terminate")
 	Eventually(func() ([]corev1.Pod, error) {
 		podList := corev1.PodList{}
@@ -147,9 +142,7 @@ func EventuallyOperandIsNotFound(testData TestData) {
 func EventuallyOperandIsFound(testData TestData) {
 	EventuallyIsFound(testData.HandlerKey, &appsv1.DaemonSet{}, "should create handler daemonset")
 	EventuallyIsFound(testData.WebhookKey, &appsv1.Deployment{}, "should create webhook deployment")
-	if !IsOpenShift() {
-		EventuallyIsFound(testData.CertManagerKey, &appsv1.Deployment{}, "should create cert-manager deployment")
-	}
+	EventuallyIsFound(testData.CertManagerKey, &appsv1.Deployment{}, "should create cert-manager deployment")
 }
 
 func InstallOperator(operator TestData) {
@@ -180,11 +173,4 @@ func UninstallOperator(operator TestData) {
 	}
 	Expect(testenv.Client.Delete(context.TODO(), &ns)).To(SatisfyAny(Succeed(), WithTransform(apierrors.IsNotFound, BeTrue())))
 	EventuallyIsNotFound(types.NamespacedName{Name: operator.Ns}, &ns, "should delete the namespace")
-}
-
-func IsOpenShift() bool {
-	GinkgoHelper()
-	isOpenShift, err := cluster.IsOpenShift(testenv.Client)
-	Expect(err).ToNot(HaveOccurred())
-	return isOpenShift
 }


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
This reverts commit e25d0bb66beda98f2fae8186810ab016eeee744e.

We should have this only merged at 4.17 when 4.16 -> 4.17 path is well tested.


**Special notes for your reviewer**:

Closes https://issues.redhat.com/browse/OCPBUGS-42222

**Release note**:

```release-note
Revert openshift cert service integration
```
