### PR TITLE
openshift: Ensure new webhook secret

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -371,8 +371,19 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context, namesp
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
 			},
 		})
-		if !apierrors.IsNotFound(err) {
+		if err != nil && apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting obsolete cert-manager deployment at openshift: %w", err)
+		}
+
+		// Remove the non openshift secret
+		err = r.Client.Delete(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-webhook",
+			},
+		})
+		if err != nil && apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed deleting old webhook secret at openshift: %w", err)
 		}
 	}
 	return nil

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -181,7 +181,11 @@ spec:
       volumes:
         - name: tls-key-pair
           secret:
+{{- if not .IsOpenShift }}
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
+{{- else }}
+            secretName: {{template "handlerPrefix" .}}openshift-nmstate-webhook
+{{- end }}
 {{- if not .IsOpenShift }}
 ---
 apiVersion: apps/v1
@@ -391,7 +395,7 @@ metadata:
   name: {{template "handlerPrefix" .}}nmstate-webhook
   namespace: {{ .HandlerNamespace }}
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}nmstate-webhook
+    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}openshift-nmstate-webhook
   labels:
     app: kubernetes-nmstate
 spec:


### PR DESCRIPTION
The non openshift secret is not compatible with openshift generated version, this change a different one so they don't collide and also remove the old one.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
