### PR TITLE
OCPBUGS-44596: Mount OVS directory instead of socket file

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -366,7 +366,7 @@ spec:
             - name: nmstate-lock
               mountPath: /var/k8s_nmstate
             - name: ovs-socket
-              mountPath: /run/openvswitch/db.sock
+              mountPath: /run/openvswitch
           securityContext:
             privileged: true
           readinessProbe:
@@ -387,7 +387,7 @@ spec:
             path: /var/k8s_nmstate
         - name: ovs-socket
           hostPath:
-            path: /run/openvswitch/db.sock
+            path: /run/openvswitch
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
When mounting the OVS DB socket directly as a file (`/run/openvswitch/db.sock`) instead of mounting the whole directory, handler container loses access to the OVS DB in case of OVS daemon restart on the host. This can only be fixed by restarting the container so that it mounts again the correct file.

To remediate this, we are mounting the whole `/run/openvswitch` directory so that DB connection can be gracefully restored by the handler itself.

Closes: OCPBUGS-44596