### PR TITLE
test: add 'notsecret' keyword to the Bearer token

### DIFF
--- a/test/e2e/handler/metrics.go
+++ b/test/e2e/handler/metrics.go
@@ -28,7 +28,7 @@ import (
 func getMetrics(token string) map[string]string {
 	bearer := "Authorization: Bearer " + token
 	return indexMetrics(runner.RunAtMetricsPod("curl", "-s", "-k", "--header",
-		bearer, ":8089", "https://127.0.0.1:8443/metrics"))
+		bearer, ":8089", "https://127.0.0.1:8443/metrics", "# notsecret"))
 }
 
 func getPrometheusToken() (string, error) {


### PR DESCRIPTION
Test platform scans all the logs and removes files that contain potential secrets. As bearer token is technically a secret, we are losing all the test logs.

This change adds `# notsecret` to the curl call so it will be ignored by the scanner.