### PR TITLE
NO-JIRA: Fix 4.19 CSV references

### DIFF
--- a/manifests/stable/manifests/image-references
+++ b/manifests/stable/manifests/image-references
@@ -5,16 +5,16 @@ spec:
   - name: kubernetes-nmstate-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kubernetes-nmstate-operator:4.18
+      name: quay.io/openshift/origin-kubernetes-nmstate-operator:4.19
   - name: kubernetes-nmstate-handler
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kubernetes-nmstate-handler:4.18
+      name: quay.io/openshift/origin-kubernetes-nmstate-handler:4.19
   - name: nmstate-console-plugin-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-nmstate-console-plugin:4.18
+      name: quay.io/openshift/origin-nmstate-console-plugin:4.19
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.18
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.19

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -39,7 +39,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: kubernetes-nmstate-operator.v4.18.0
+  name: kubernetes-nmstate-operator.v4.19.0
   namespace: openshift-nmstate
 spec:
   apiservicedefinitions: {}
@@ -203,9 +203,9 @@ spec:
                         value: "6060"
                       - name: RUN_OPERATOR
                       - name: HANDLER_IMAGE
-                        value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.18
+                        value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.19
                       - name: PLUGIN_IMAGE
-                        value: quay.io/openshift/origin-nmstate-console-plugin:4.18
+                        value: quay.io/openshift/origin-nmstate-console-plugin:4.19
                       - name: HANDLER_IMAGE_PULL_POLICY
                         value: Always
                       - name: HANDLER_NAMESPACE
@@ -213,8 +213,8 @@ spec:
                       - name: MONITORING_NAMESPACE
                         value: openshift-monitoring
                       - name: KUBE_RBAC_PROXY_IMAGE
-                        value: quay.io/openshift/origin-kube-rbac-proxy:4.18
-                    image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.18
+                        value: quay.io/openshift/origin-kube-rbac-proxy:4.19
+                    image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.19
                     imagePullPolicy: Always
                     name: nmstate-operator
                     resources:
@@ -286,4 +286,4 @@ spec:
   selector:
     matchLabels:
       name: kubernetes-nmstate-operator
-  version: 4.18.0
+  version: 4.19.0


### PR DESCRIPTION
Fix CSV validation by ART, currently failing with:
```
Bundle ose-kubernetes-nmstate-operator-bundle-container-v4.19.0.202502102307.p0.g86a8cd3.assembly.stream.el9-2 CSV metadata.name has no datestamp: kubernetes-nmstate-operator.v4.18.0
Bundle ose-kubernetes-nmstate-operator-bundle-container-v4.19.0.202502102307.p0.g86a8cd3.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.18.0
```