### PR TITLE
[release-4.18]: operator, Continue on cleanup NotFound errors (#1302)

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -378,7 +378,7 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-cert-manager",
 			},
 		})
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting obsolete cert-manager deployment at openshift: %w", err)
 		}
 
@@ -389,7 +389,7 @@ func (r *NMStateReconciler) cleanupObsoleteResources(ctx context.Context) error 
 				Name:      os.Getenv("HANDLER_PREFIX") + "nmstate-webhook",
 			},
 		})
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed deleting old webhook secret at openshift: %w", err)
 		}
 	}


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The operator check if it has to remove old cert-manager stuff for openshift but it fails is they are not found, so it enters an Reconcile infinite loop.

This change just fail if there is an error but is different that NotFound.

**Special notes for your reviewer**:
Backport from upstream of:
- https://github.com/nmstate/kubernetes-nmstate/pull/1302

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Continue on cleanup NotFound errors
```
