### PR TITLE
[release-4.18] Enable debug logging of nmstate apply (#1294)

### DIFF
--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -78,7 +78,7 @@ func Set(desiredState nmstate.State, timeout time.Duration) (string, error) {
 	defer close(setDoneCh)
 
 	setOutput, err := nmstatectlWithInput(
-		[]string{"apply", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
+		[]string{"apply", "-v", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
 		string(desiredState.Raw),
 	)
 	return setOutput, err


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind enhancement

**What this PR does / why we need it**:
Enable debug logging of nmstate apply, this could help developer to debug issue when something broken.

**Special notes for your reviewer**:
Cherry-pick from https://github.com/nmstate/kubernetes-nmstate/pull/1294

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Use verbose mode for nmstatectl apply
```
