### PR TITLE
deps: fix yq version v4.35.2 regex

### DIFF
--- a/hack/ocp-bundle-common.sh
+++ b/hack/ocp-bundle-common.sh
@@ -3,7 +3,7 @@
 set -ex
 
 function yq4 {
-  VERSION_REGEX=" version 4\.[0-9]+\.[0-9]$"
+  VERSION_REGEX=" version v?4\.[0-9]+\.[0-9]$"
   if [[ "`yq --version`" =~ $VERSION_REGEX ]]; then
     # installed yq version is v4 -> we are OK
     echo yq


### PR DESCRIPTION
version starts with `v` now

```shell
+ yq4
+ VERSION_REGEX=' version v?4\.[0-9]+\.[0-9]$'
++ yq --version
+ [[ yq 3.4.3 =~  version v?4\.[0-9]+\.[0-9]$ ]]
++ pwd
+ INSTALL_DIR=/home/bob/kubernetes-nmstate/build/_output/bin
+ [[ -f /home/bob/kubernetes-nmstate/build/_output/bin/yq ]]
++ /home/bob/kubernetes-nmstate/build/_output/bin/yq --version
+ [[ yq (https://github.com/mikefarah/yq/) version v4.35.2 =~  version v?4\.[0-9]+\.[0-9]$ ]]
+ echo /home/bob/kubernetes-nmstate/build/_output/bin/yq
```


/kind bug


**What this PR does / why we need it**:

Reduces build noise.  `yq4` will re-run go install every time.

```release-note
Fixed yq4 version check regex.
```
