### PR TITLE
UPSTREAM<carry>: makefile: manually bring changes from #1335 upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ export SSH ?= ./cluster/ssh.sh
 export KUBECTL ?= ./cluster/kubectl.sh
 
 KUBECTL ?= ./cluster/kubectl.sh
-OPERATOR_SDK_VERSION ?= 1.22.2
+OPERATOR_SDK_VERSION ?= 1.37.0
 
 GINKGO = GOFLAGS=-mod=mod go run github.com/onsi/ginkgo/v2/ginkgo@v2.11.0
 CONTROLLER_GEN = GOFLAGS=-mod=mod go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.1
@@ -169,7 +169,7 @@ check-bundle: bundle
 	git diff --exit-code -I'^    createdAt: ' -s bundle || (echo "It seems like you need to run 'make bundle'. Please run it and commit the changes" && git diff && exit 1)
 
 check-ocp-bundle: ocp-update-bundle-manifests
-	./hack/check-gen.sh ocp-update-bundle-manifests
+	git diff --exit-code -I'^    createdAt: ' -s bundle || (echo "It seems like you need to run 'make bundle'. Please run it and commit the changes" && git diff && exit 1)
 
 generate: gen-k8s gen-crds gen-rbac
 
@@ -276,7 +276,7 @@ bundle-build:
 
 # Build the index
 index-build: bundle-build
-	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(INDEX_IMG) --build-tool $(IMAGE_BUILDER) --binary-image quay.io/operator-framework/opm:v1.24.0
+	$(OPM) index add --bundles $(BUNDLE_IMG) --tag $(INDEX_IMG) --build-tool $(IMAGE_BUILDER) --binary-image quay.io/operator-framework/opm:v${OPERATOR_SDK_VERSION}-amd64
 
 bundle-push: bundle-build
 	$(IMAGE_BUILDER) push $(BUNDLE_IMG)

--- a/manifests/stable/bundle.Dockerfile
+++ b/manifests/stable/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kubernetes-nmstate-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable,alpha
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     olm.skipRange: '>=4.3.0 <4.19.0'
     operatorframework.io/suggested-namespace: openshift-nmstate
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.22.2
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/kubernetes-nmstate
     support: Red Hat, Inc.

--- a/manifests/stable/metadata/annotations.yaml
+++ b/manifests/stable/metadata/annotations.yaml
@@ -6,6 +6,6 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: kubernetes-nmstate-operator
   operators.operatorframework.io.bundle.channels.v1: stable,alpha
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
Some changes from
https://github.com/nmstate/kubernetes-nmstate/pull/1335 got lost during the automatic rebase proces. Mainly due to the fact that we have lots of downstream-only commits and the git history is a bit of a mess.

This commit brings back missing changes.