### PR TITLE
OCPBUGS-55353: Add retry logic for failing NNCP with exponential backoff cooldown

### DIFF
--- a/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/api/shared/nodenetworkconfigurationenactment_types.go
@@ -43,6 +43,9 @@ type NodeNetworkConfigurationEnactmentStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty"`
 
 	Features []string `json:"features,omitempty"`
+
+	// +kubebuilder:default=0
+	RetryCount int `json:"retryCount"`
 }
 
 type NodeNetworkConfigurationEnactmentCapturedState struct {

--- a/controllers/handler/nodenetworkconfigurationpolicy_controller.go
+++ b/controllers/handler/nodenetworkconfigurationpolicy_controller.go
@@ -63,7 +63,9 @@ import (
 )
 
 const (
-	ReconcileFailed = "ReconcileFailed"
+	ReconcileFailed         = "ReconcileFailed"
+	Retrying                = "Retrying"
+	MaximumReconcileRetries = 5
 )
 
 var (
@@ -226,14 +228,42 @@ func (r *NodeNetworkConfigurationPolicyReconciler) Reconcile(_ context.Context, 
 
 	nmstateOutput, err := nmstate.ApplyDesiredState(r.APIClient, enactmentInstance.Status.DesiredState)
 	if err != nil {
-		errmsg := fmt.Errorf("error reconciling NodeNetworkConfigurationPolicy on node %s at desired state apply: %q,\n %v",
-			nodeName, nmstateOutput, err)
-		enactmentConditions.NotifyFailedToConfigure(errmsg)
-		log.Error(errmsg, fmt.Sprintf("Rolling back network configuration, manual intervention needed: %s", nmstateOutput))
-		if r.Recorder != nil {
-			r.Recorder.Event(instance, corev1.EventTypeWarning, ReconcileFailed, errmsg.Error())
+		enactmentCopy := enactmentInstance.DeepCopy()
+		enactmentCopy.Status.RetryCount += 1
+
+		retryCount := enactmentCopy.Status.RetryCount
+
+		err2 := enactmentstatus.Update(
+			r.APIClient,
+			nmstateapi.EnactmentKey(nodeName, instance.Name),
+			func(status *nmstateapi.NodeNetworkConfigurationEnactmentStatus) {
+				status.RetryCount = enactmentCopy.Status.RetryCount
+			},
+		)
+		if err2 != nil {
+			errmsg := fmt.Errorf("error failed to update enactment status: %v", err2)
+			enactmentConditions.NotifyFailedToConfigure(errmsg)
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
+
+		if retryCount < MaximumReconcileRetries {
+			errmsg := fmt.Errorf("error (Retry: %d/5)  reconciling NodeNetworkConfigurationPolicy on node %s at desired state apply: %q,\n %v",
+				retryCount, nodeName, nmstateOutput, err)
+			enactmentConditions.NotifyProgressing()
+			log.Error(errmsg, fmt.Sprintf("Rolling back network configuration, manual intervention needed: %s", nmstateOutput))
+			if r.Recorder != nil {
+				r.Recorder.Event(instance, corev1.EventTypeWarning, Retrying, errmsg.Error())
+			}
+			return ctrl.Result{RequeueAfter: time.Duration(retryCount) * time.Second}, nil
+		} else {
+			errmsg := fmt.Errorf("error reached max tries reconciling NodeNetworkConfigurationPolicy on node %s at desired state apply: %q,\n %v",
+				nodeName, nmstateOutput, err)
+			enactmentConditions.NotifyFailedToConfigure(errmsg)
+			if r.Recorder != nil {
+				r.Recorder.Event(instance, corev1.EventTypeWarning, ReconcileFailed, errmsg.Error())
+			}
+			return ctrl.Result{}, nil
+		}
 	}
 	log.Info("nmstate", "output", nmstateOutput)
 

--- a/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationenactments.yaml
@@ -120,6 +120,11 @@ spec:
                   condition status belongs to the same policy version
                 format: int64
                 type: integer
+              retryCount:
+                default: 0
+                type: integer
+            required:
+            - retryCount
             type: object
         type: object
         x-kubernetes-preserve-unknown-fields: true

--- a/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationenactment_types.go
+++ b/vendor/github.com/nmstate/kubernetes-nmstate/api/shared/nodenetworkconfigurationenactment_types.go
@@ -43,6 +43,9 @@ type NodeNetworkConfigurationEnactmentStatus struct {
 	Conditions ConditionList `json:"conditions,omitempty"`
 
 	Features []string `json:"features,omitempty"`
+	
+	// +kubebuilder:default=0
+	RetryCount int `json:"retryCount"`
 }
 
 type NodeNetworkConfigurationEnactmentCapturedState struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

/kind enhancement

**What this PR does / why we need it**:
This PR is introducing a retry logic for failing `NNCP` by attaching a `retryCounter` to the `status` property of a `NNCE`. The current logic is using an exponential backoff with the timeout being `1s * amountRetries` up until 5 retries. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The reconcile loop will now retry applying failing NNCP up to 5 times with an exponential backoff of (1s * amountRetries). 
```
