### PR TITLE
UPSTREAM: <carry>: Fix adding network policy to OLM bundle

### DIFF
--- a/hack/ocp-bundle-common.sh
+++ b/hack/ocp-bundle-common.sh
@@ -27,6 +27,7 @@ fi
 
 export BUNDLE_DIR="${BUNDLE_DIR:-manifests/${CHANNEL}}"
 MANIFEST_BASES_DIR=manifests/bases
+export MANIFESTS_DIR="${MANIFESTS_DIR:-build/_output/manifests}"
 
 if [ -z "${VERSION}" ]; then
     export VERSION="$($(yq4) '.spec.version' ${BUNDLE_DIR}/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml)"


### PR DESCRIPTION
This PR adds a missing `MANIFESTS_DIR` variable which was defined in Makefile but not in the OCP common script.

This is needed because there are cases where ocp-update-bundle-manifest is run directly as a script and not via make target (e.g. when rebasebot runs in a non-interactive mode).