### PR TITLE
operator: use strategic merge to prevent losing labels

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -511,8 +511,11 @@ func (r *NMStateReconciler) apply(ctx context.Context, newObj *unstructured.Unst
 		return nil
 	}
 	newObj.SetResourceVersion(oldObj.GetResourceVersion())
-	if err := r.Client.Patch(ctx, newObj, client.MergeFrom(oldObj)); err != nil {
-		return fmt.Errorf("failed patching %q \"%s:%s: %w", newObj.GetKind(), newObj.GetNamespace(), newObj.GetName(), err)
+	if err := r.Client.Patch(ctx, newObj, client.StrategicMergeFrom(oldObj)); err != nil {
+		if err := r.Client.Patch(ctx, newObj, client.MergeFrom(oldObj)); err != nil {
+			return fmt.Errorf("failed patching %q \"%s:%s: %w", newObj.GetKind(), newObj.GetNamespace(), newObj.GetName(), err)
+		}
+		r.Log.Info("failed strategic patch but succeeded fallback %q \"%s:%s", newObj.GetKind(), newObj.GetNamespace(), newObj.GetName())
 	}
 	return nil
 }


### PR DESCRIPTION
We are changing MergeFrom to StrategicMergeFrom so that when applying manifests we do not lose any content.

When using MergeFrom, if the desired namespace contains a custom label or custom annotation it will be wiped because we set namespace labels. In this case the lists are not merged but forcefully overriden.

When using StrategicMergeFrom, lists are correctly merged. As a result, custom annotations are not removed.

In principle this apply to every field that is a list, not only to the namespace labels and annotations.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Custom labels and annotations on the namespace are no longer dropped when starting nmstate-operator pod.
```
