### PR TITLE
OCPBUGS-60452: Revert deadlock introduced by verbose output

### DIFF
--- a/pkg/nmstatectl/nmstatectl.go
+++ b/pkg/nmstatectl/nmstatectl.go
@@ -91,7 +91,7 @@ func Set(desiredState nmstate.State, timeout time.Duration) (string, error) {
 	defer close(setDoneCh)
 
 	setOutput, err := nmstatectlWithInput(
-		[]string{"apply", "-v", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
+		[]string{"apply", "--no-commit", "--timeout", strconv.Itoa(int(timeout.Seconds()))},
 		string(desiredState.Raw),
 	)
 	return setOutput, err


### PR DESCRIPTION
Revert "Enable debug logging of nmstate apply (#1294)". This reverts commit c8e67f84ad940b8d699590c71ba71085c9f30699.

Fixes: OCPBUGS-60452