### PR TITLE
UPSTREAM: <carry>: Update maintainers, sync upstream

### DIFF
--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -24,4 +24,4 @@ LABEL io.k8s.display-name="kubernetes-nmstate-operator" \
       io.k8s.description="Operator for Node network configuration through Kubernetes API" \
       io.openshift.tags="openshift,kubernetes-nmstate-operator" \
       com.redhat.delivery.appregistry=true \
-      maintainer="Yossi Boaron <yboaron@redhat.com>"
+      org.opencontainers.image.authors="Enrique Llorente Pastora <ellorent@redhat.com>, Mateusz Kowalski <mko@redhat.com>"


### PR DESCRIPTION
Manually sync https://github.com/nmstate/kubernetes-nmstate/pull/1351 with downstream. Some changes were lost during rebase as the file has been modified from the original upstream version.

This PR carries missing change from the
8f73b0e10e611c82a263a02e54bca41338847cc7 commit.