### PR TITLE
OCPBUGS-62314: Fix nmstate-console-plugin NetworkPolicy

### DIFF
--- a/deploy/openshift/ui-plugin/network_policy.yaml
+++ b/deploy/openshift/ui-plugin/network_policy.yaml
@@ -8,7 +8,6 @@ spec:
   podSelector:
     matchLabels:
       app: {{ .PluginName }}
-      component: {{ .PluginName }}
   ingress:
     - ports:
         - protocol: TCP


### PR DESCRIPTION
Currently, the `allow-plugin-nmstate-console-plugin-ingress NetworkPolicy` targets the nmstate-console-plugin pod by these labels:
```
app: nmstate-console-plugin
component: nmstate-console-plugin
```

however, the nmstate-console-plugin pod is labelled only with the first label (app), not the second (component). Thus, the netpol does not act on that pod and doesn't allow it any access. Since it is not possible to update the label selectors of a Deployment with RollingUpdate, we need to remove the 2nd label, so that the netpol will act on the console-plugin pod and allow ingress access to it.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix nmstate-console-plugin NetworkPolicy
```
