### PR TITLE
Fix networkpolicy and role binding manifests

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -143,8 +143,8 @@ metadata:
   namespace: {{ .OperatorNamespace }}
 spec:
   podSelector:
-  matchLabels:
-    app: kubernetes-nmstate-operator
+    matchLabels:
+      app: kubernetes-nmstate-operator
   policyTypes:
     - Ingress
     - Egress
@@ -156,8 +156,8 @@ metadata:
   namespace: {{ .HandlerNamespace }}
 spec:
   podSelector:
-  matchLabels:
-    app: kubernetes-nmstate
+    matchLabels:
+      app: kubernetes-nmstate
   policyTypes:
     - Ingress
     - Egress

--- a/deploy/handler/role_binding.yaml
+++ b/deploy/handler/role_binding.yaml
@@ -41,7 +41,6 @@ roleRef:
   kind: Role
   apiGroup: rbac.authorization.k8s.io
   name: {{template "handlerPrefix" .}}nmstate-handler-events
-  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Some minor details were fixed upstream via
https://github.com/nmstate/kubernetes-nmstate/pull/1334 and synced downstream. This PR gets this change to 4.20 so that we always ship the same policies.