### PR TITLE
NO-JIRA: Update container image version in CSV to 4.20

### DIFF
--- a/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     categories: OpenShift Optional
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
-    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.19
+    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.20
     createdAt: "2022-02-21 08:46:16"
     olm.skipRange: ">=4.3.0 <4.20.0"
     support: Red Hat, Inc.

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.19
+    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.20
     createdAt: "2025-08-20T05:45:09Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.


### PR DESCRIPTION
https://github.com/openshift/kubernetes-nmstate/commit/ddef7a49367ed6a3337071ccc40914243cf3560a bumped image references to 4.20 but the CSV file still reference to 4.19, which breaks the production build.

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
