### PR TITLE
UPSTREAM: <carry>: Unhold network policy in the OLM bundle

### DIFF
--- a/hack/ocp-update-bundle-manifests.sh
+++ b/hack/ocp-update-bundle-manifests.sh
@@ -44,12 +44,9 @@ $(yq4) --inplace '.metadata.annotations."olm.skipRange" style="double"' ${BUNDLE
 # delete unneeded files
 rm -f ${BUNDLE_DIR}/manifests/nmstate.io_nodenetwork*.yaml
 
-# Network policy support did not make it into OCP 4.20. We must not add manifests to the bundle.
-# Doing so will break the validation pipeline. Once OLM gets the feature, uncomment the following lines.
-#
-# # Add network policies to the bundle. They will be used as-is by the OLM in OCP 4.20 and later.
-# cp ${MANIFESTS_DIR}/network-policy-default-deny-all.yaml ${BUNDLE_DIR}/manifests/network-policy-default-deny-all.yaml
-# cp ${MANIFESTS_DIR}/network-policy-allow-egress-to-api-server.yaml ${BUNDLE_DIR}/manifests/network-policy-allow-egress-to-api-server.yaml
+# Add network policies to the bundle. They will be used as-is by the OLM in OCP 4.20 and later.
+cp ${MANIFESTS_DIR}/network-policy-default-deny-all.yaml ${BUNDLE_DIR}/manifests/network-policy-default-deny-all.yaml
+cp ${MANIFESTS_DIR}/network-policy-allow-egress-to-api-server.yaml ${BUNDLE_DIR}/manifests/network-policy-allow-egress-to-api-server.yaml
 
 # save new bundle.Dockerfile with new paths
 sed 's#manifests\/$(CHANNEL)/##g' bundle.Dockerfile > ${BUNDLE_DIR}/bundle.Dockerfile

--- a/manifests/stable/manifests/network-policy-allow-egress-to-api-server.yaml
+++ b/manifests/stable/manifests/network-policy-allow-egress-to-api-server.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-api-6443-olm
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 6443
+  policyTypes:
+    - Egress

--- a/manifests/stable/manifests/network-policy-default-deny-all.yaml
+++ b/manifests/stable/manifests/network-policy-default-deny-all.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-labelled-operator-olm
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
Revert https://github.com/openshift/kubernetes-nmstate/pull/646. OLM should be good for network policies in the bundle.