### PR TITLE
metrics: Replace kube-rbac-proxy with built-in authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,6 @@ OPERATOR_IMAGE_TAG ?= latest
 OPERATOR_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
 OPERATOR_IMAGE ?= $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE_FULL_NAME)
 
-KUBE_RBAC_PROXY_NAME ?= origin-kube-rbac-proxy
-KUBE_RBAC_PROXY_TAG ?= 4.10.0
-KUBE_RBAC_PROXY_IMAGE_REGISTRY ?= quay.io
-KUBE_RBAC_PROXY_IMAGE_REPO ?= openshift
-KUBE_RBAC_PROXY_FULL_NAME ?= $(KUBE_RBAC_PROXY_IMAGE_REPO)/$(KUBE_RBAC_PROXY_NAME):$(KUBE_RBAC_PROXY_TAG)
-KUBE_RBAC_PROXY_IMAGE ?= $(KUBE_RBAC_PROXY_IMAGE_REGISTRY)/$(KUBE_RBAC_PROXY_FULL_NAME)
-
 PLUGIN_IMAGE_NAME ?= nmstate-console-plugin
 PLUGIN_IMAGE_TAG ?= latest
 PLUGIN_IMAGE_FULL_NAME ?= $(IMAGE_REPO)/$(PLUGIN_IMAGE_NAME):$(PLUGIN_IMAGE_TAG)
@@ -184,7 +177,7 @@ check-ocp-bundle: ocp-update-bundle-manifests
 generate: gen-k8s gen-crds gen-rbac
 
 manifests:
-	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -monitoring-namespace=$(MONITORING_NAMESPACE) -kube-rbac-proxy-image=$(KUBE_RBAC_PROXY_IMAGE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -plugin-image=$(PLUGIN_IMAGE) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
+	GOFLAGS=-mod=mod go run hack/render-manifests.go -handler-prefix=$(HANDLER_PREFIX) -handler-namespace=$(HANDLER_NAMESPACE) -operator-namespace=$(OPERATOR_NAMESPACE) -handler-image=$(HANDLER_IMAGE) -operator-image=$(OPERATOR_IMAGE) -handler-pull-policy=$(HANDLER_PULL_POLICY) -monitoring-namespace=$(MONITORING_NAMESPACE) -operator-pull-policy=$(OPERATOR_PULL_POLICY) -plugin-image=$(PLUGIN_IMAGE) -input-dir=deploy/ -output-dir=$(MANIFESTS_DIR)
 
 handler: SKIP_PUSH=true
 handler: push-handler

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -267,8 +267,6 @@ spec:
                   value: monitoring
                 - name: OPERATOR_NAMESPACE
                   value: nmstate
-                - name: KUBE_RBAC_PROXY_IMAGE
-                  value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -342,7 +342,6 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["HandlerPullPolicy"] = os.Getenv("HANDLER_IMAGE_PULL_POLICY")
 	data.Data["HandlerPrefix"] = os.Getenv("HANDLER_PREFIX")
 	data.Data["MonitoringNamespace"] = os.Getenv("MONITORING_NAMESPACE")
-	data.Data["KubeRBACProxyImage"] = os.Getenv("KUBE_RBAC_PROXY_IMAGE")
 	data.Data["InfraNodeSelector"] = infraNodeSelector
 	data.Data["InfraTolerations"] = infraTolerations
 	data.Data["WebhookAffinity"] = infraAffinity

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -120,7 +120,6 @@ var _ = Describe("NMState controller reconcile", func() {
 		webhookKey          = types.NamespacedName{Namespace: handlerNamespace, Name: handlerPrefix + "-nmstate-webhook"}
 		handlerImage        = "quay.io/some_image"
 		monitoringNamespace = "monitoring"
-		kubeRBACProxyImage  = "quay.io/some_kube_rbac_proxy_image"
 		imagePullPolicy     = "Always"
 		manifestsDir        = ""
 		newNMState          = func() *nmstatev1.NMState {
@@ -183,7 +182,6 @@ var _ = Describe("NMState controller reconcile", func() {
 		os.Setenv("HANDLER_IMAGE_PULL_POLICY", imagePullPolicy)
 		os.Setenv("HANDLER_PREFIX", handlerPrefix)
 		os.Setenv("MONITORING_NAMESPACE", monitoringNamespace)
-		os.Setenv("KUBE_RBAC_PROXY_IMAGE", kubeRBACProxyImage)
 	})
 	AfterEach(func() {
 		err := os.RemoveAll(manifestsDir)

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -49,6 +49,10 @@ spec:
           imagePullPolicy: {{ .HandlerPullPolicy }}
           command:
           - manager
+          ports:
+          - containerPort: 8443
+            name: metrics
+            protocol: TCP
           resources:
             requests:
               cpu: "30m"
@@ -57,6 +61,19 @@ spec:
               cpu: "500m"
               memory: "1Gi"
           terminationMessagePolicy: FallbackToLogsOnError
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
           env:
             - name: WATCH_NAMESPACE
               value: ""
@@ -76,43 +93,21 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
-        - args:
-          - --logtostderr
-          - --secure-listen-address=:8443
-          - --upstream=http://127.0.0.1:8089
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-          image: {{ .KubeRBACProxyImage }}
-          imagePullPolicy: IfNotPresent
-          name: kube-rbac-proxy
-          ports:
-          - containerPort: 8443
-            name: metrics
-            protocol: TCP
-          readinessProbe:
-            tcpSocket:
-              port: metrics
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          livenessProbe:
-            tcpSocket:
-              port: metrics
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-          resources:
-            requests:
-              cpu: "10m"
-              memory: "20Mi"
-            limits:
-              cpu: "500m"
-              memory: "1Gi"
-          terminationMessagePolicy: FallbackToLogsOnError
+            - name: METRICS_BIND_ADDRESS
+              value: ":8443"
+            - name: METRICS_SECURE
+              value: "true"
+            - name: METRICS_CERT_DIR
+              value: "/tmp/k8s-metrics-server/serving-certs"
+          volumeMounts:
+            - name: metrics-certs
+              mountPath: /tmp/k8s-metrics-server/serving-certs
+              readOnly: true
+      volumes:
+        - name: metrics-certs
+          secret:
+            secretName: {{template "handlerPrefix" .}}nmstate-metrics-tls
+            optional: true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -491,6 +486,8 @@ metadata:
   namespace: {{ .HandlerNamespace }}
   labels:
     prometheus.nmstate.io: "true"
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{template "handlerPrefix" .}}nmstate-metrics-tls
 spec:
   ports:
     - name: metrics

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -107,5 +107,3 @@ spec:
               value: {{ .MonitoringNamespace }}
             - name: OPERATOR_NAMESPACE
               value: {{ .OperatorNamespace }}
-            - name: KUBE_RBAC_PROXY_IMAGE
-              value: {{ .KubeRBACProxyImage }}

--- a/hack/render-manifests.go
+++ b/hack/render-manifests.go
@@ -42,7 +42,6 @@ func main() {
 		OperatorImage       string
 		OperatorPullPolicy  string
 		MonitoringNamespace string
-		KubeRBACProxyImage  string
 		PluginImage         string
 	}
 
@@ -54,7 +53,6 @@ func main() {
 	operatorImage := flag.String("operator-image", "", "Image for the NMState operator")
 	operatorPullPolicy := flag.String("operator-pull-policy", "Always", "Pull policy for the NMState operator image")
 	monitoringNamespace := flag.String("monitoring-namespace", "monitoring", "Namespace for the cluster monitoring")
-	kubeRBACProxyImage := flag.String("kube-rbac-proxy-image", "", "Image for the kube RBAC proxy needed for metrics")
 	pluginImage := flag.String("plugin-image", "", "Image for the NMState console plugin")
 	inputDir := flag.String("input-dir", "", "Input directory")
 	outputDir := flag.String("output-dir", "", "Output directory")
@@ -69,7 +67,6 @@ func main() {
 		OperatorImage:       *operatorImage,
 		OperatorPullPolicy:  *operatorPullPolicy,
 		MonitoringNamespace: *monitoringNamespace,
-		KubeRBACProxyImage:  *kubeRBACProxyImage,
 		PluginImage:         *pluginImage,
 	}
 

--- a/pkg/metrics/filters/filters.go
+++ b/pkg/metrics/filters/filters.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package filters provides authentication and authorization filters for the metrics server.
+// This is a local implementation of the controller-runtime metrics filters for projects
+// that don't have the filters package vendored.
+package filters
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-logr/logr"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const (
+	// debugLogLevel is the verbosity level for debug log messages
+	debugLogLevel = 4
+)
+
+// WithAuthenticationAndAuthorization provides a metrics.Filter for authentication and authorization.
+// Metrics will be authenticated (via TokenReviews) and authorized (via SubjectAccessReviews) with the kube-apiserver.
+//
+// For the authentication and authorization the controller needs a ClusterRole with the following rules:
+//   - apiGroups: authentication.k8s.io
+//     resources:
+//   - tokenreviews
+//     verbs:
+//   - create
+//   - apiGroups: authorization.k8s.io
+//     resources:
+//   - subjectaccessreviews
+//     verbs:
+//   - create
+//
+// To scrape metrics (e.g. via Prometheus), the client needs a ClusterRole with the following rule:
+//   - nonResourceURLs: "/metrics"
+//     verbs:
+//   - get
+func WithAuthenticationAndAuthorization(config *rest.Config, httpClient *http.Client) (metricsserver.Filter, error) {
+	clientset, err := kubernetes.NewForConfigAndClient(config, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(log logr.Logger, handler http.Handler) (http.Handler, error) {
+		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			ctx := req.Context()
+
+			// Extract bearer token from Authorization header
+			authHeader := req.Header.Get("Authorization")
+			if authHeader == "" {
+				sendUnauthorized(w, log, "No Authorization header found")
+				return
+			}
+
+			// Check for Bearer token
+			const bearerPrefix = "Bearer "
+			if !strings.HasPrefix(authHeader, bearerPrefix) {
+				sendUnauthorized(w, log, "Authorization header is not a Bearer token")
+				return
+			}
+			token := strings.TrimPrefix(authHeader, bearerPrefix)
+
+			// Authenticate via TokenReview
+			tokenReview := &authenticationv1.TokenReview{
+				Spec: authenticationv1.TokenReviewSpec{
+					Token: token,
+				},
+			}
+
+			result, err := clientset.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
+			if err != nil {
+				log.Error(err, "TokenReview failed")
+				http.Error(w, "Authentication failed", http.StatusInternalServerError)
+				return
+			}
+
+			if !result.Status.Authenticated {
+				sendUnauthorized(w, log, "Token is not authenticated", "error", result.Status.Error)
+				return
+			}
+
+			// Authorize via SubjectAccessReview
+			sar := &authorizationv1.SubjectAccessReview{
+				Spec: authorizationv1.SubjectAccessReviewSpec{
+					User:   result.Status.User.Username,
+					Groups: result.Status.User.Groups,
+					NonResourceAttributes: &authorizationv1.NonResourceAttributes{
+						Path: req.URL.Path,
+						Verb: strings.ToLower(req.Method),
+					},
+				},
+			}
+
+			sarResult, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+			if err != nil {
+				log.Error(err, "SubjectAccessReview failed")
+				http.Error(w, "Authorization failed", http.StatusInternalServerError)
+				return
+			}
+
+			if !sarResult.Status.Allowed {
+				log.V(debugLogLevel).Info("Request not authorized", "user", result.Status.User.Username, "reason", sarResult.Status.Reason)
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			// Serve the request
+			handler.ServeHTTP(w, req)
+		}), nil
+	}, nil
+}
+
+func sendUnauthorized(w http.ResponseWriter, log logr.Logger, msg string, keysAndValues ...any) {
+	log.V(debugLogLevel).Info(msg, keysAndValues...)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}

--- a/test/e2e/handler/metrics.go
+++ b/test/e2e/handler/metrics.go
@@ -28,7 +28,7 @@ import (
 func getMetrics(token string) map[string]string {
 	bearer := "Authorization: Bearer " + token
 	return indexMetrics(runner.RunAtMetricsPod("curl", "-s", "-k", "--header",
-		bearer, "--header", "X-Authorization-Classification: notsecret", ":8089", "https://127.0.0.1:8443/metrics"))
+		bearer, "--header", "X-Authorization-Classification: notsecret", "https://127.0.0.1:8443/metrics"))
 }
 
 func getPrometheusToken() (string, error) {


### PR DESCRIPTION
Replace the kube-rbac-proxy sidecar in the nmstate-metrics Deployment with controller-runtime's built-in WithAuthenticationAndAuthorization filter for metrics authentication and authorization.

The existing RBAC permissions for tokenreviews and subjectaccessreviews in the handler ClusterRole are sufficient for this functionality.

"
(cherry picked from commit fdb9090c6612cd1a70f892c04e99c3ab50e852c5)

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
