### PR TITLE
[DNM] fix(handler): eliminate API server dependency at startup for TLS config

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kubernetes-nmstate-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -9,87 +9,19 @@ metadata:
           "kind": "NMState",
           "metadata": {
             "name": "nmstate"
-          }
-        },
-        {
-          "apiVersion": "nmstate.io/v1",
-          "kind": "NodeNetworkConfigurationPolicy",
-          "metadata": {
-            "name": "example-nodenetworkconfigurationpolicy"
           },
-          "spec": {
-            "desiredState": {
-              "interfaces": [
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth1"
-                      }
-                    ]
-                  },
-                  "name": "br0",
-                  "state": "up",
-                  "type": "linux-bridge"
-                },
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth2"
-                      }
-                    ]
-                  },
-                  "name": "br1",
-                  "state": "up",
-                  "type": "linux-bridge"
-                },
-                {
-                  "bridge": {
-                    "options": {
-                      "stp": {
-                        "enabled": false
-                      }
-                    },
-                    "port": [
-                      {
-                        "name": "eth3"
-                      }
-                    ]
-                  },
-                  "ipv4": {
-                    "auto-dns": false,
-                    "dhcp": true,
-                    "enabled": true
-                  },
-                  "name": "br3",
-                  "state": "up",
-                  "type": "linux-bridge"
-                }
-              ]
-            }
-          }
+          "spec": {}
         }
       ]
     capabilities: Basic Install
     categories: Networking
     certified: "false"
-    containerImage: quay.io/nmstate/kubernetes-nmstate-operator:latest
-    createdAt: "2026-03-11T11:36:25Z"
+    containerImage: $OPERATOR_IMAGE
+    createdAt: "2026-03-26T06:44:40Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     operatorframework.io/suggested-namespace: nmstate
-    operators.operatorframework.io/builder: operator-sdk-v1.22.2
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/internal-objects: '["nodenetworkconfigurationenactments.nmstate.io",
       "nodenetworkstates.nmstate.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -173,6 +105,14 @@ spec:
           - statefulsets
           verbs:
           - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - apiservers
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - console.openshift.io
           resources:
@@ -261,8 +201,10 @@ spec:
                 - name: RUN_OPERATOR
                 - name: HANDLER_IMAGE
                   value: quay.io/nmstate/kubernetes-nmstate-handler:latest
+                - name: PLUGIN_IMAGE
+                  value: quay.io/nmstate/nmstate-console-plugin:latest
                 - name: HANDLER_IMAGE_PULL_POLICY
-                  value: IfNotPresent
+                  value: Always
                 - name: HANDLER_NAMESPACE
                   value: nmstate
                 - name: MONITORING_NAMESPACE
@@ -272,7 +214,7 @@ spec:
                 - name: KUBE_RBAC_PROXY_IMAGE
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
-                imagePullPolicy: IfNotPresent
+                imagePullPolicy: Always
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kubernetes-nmstate-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -73,7 +72,10 @@ import (
 	"github.com/nmstate/kubernetes-nmstate/pkg/webhook"
 )
 
-const generalExitStatus int = 1
+const (
+	generalExitStatus    int    = 1
+	tlsProfileConfigPath string = "/etc/nmstate/tls/profile.json"
+)
 
 type ProfilerConfig struct {
 	EnableProfiler bool   `envconfig:"ENABLE_PROFILER"`
@@ -137,37 +139,36 @@ func mainHandler() int {
 
 	cfg := ctrl.GetConfigOrDie()
 
-	// Detect OpenShift and fetch TLS profile early, before creating the
-	// manager, so both the metrics server and webhooks share the same config.
-	platformTLSOpts, err := cluster.FetchOpenShiftTLSOpts(cfg, scheme)
-	if err != nil {
-		setupLog.Error(err, "unable to fetch TLS configuration")
-		return generalExitStatus
+	// Detect OpenShift from env var set by the operator, avoiding an API
+	// server call that can fail when network connectivity is temporarily
+	// unavailable (e.g. during default interface reconfiguration).
+	isOpenShift := cluster.IsOpenShiftFromEnv()
+
+	var platformTLSOpts func(*tls.Config)
+	// Only load TLS profile on OpenShift for components that serve TLS
+	// (webhook and metrics). The handler DaemonSet uses default TLS.
+	// Read from a ConfigMap-mounted file to avoid API server calls.
+	// TLS profile changes are handled by the operator: it updates the
+	// ConfigMap and rolls the Deployments via a hash annotation.
+	if isOpenShift && !environment.IsHandler() {
+		opts, _, err := cluster.FetchTLSProfileFromFile(tlsProfileConfigPath)
+		if err != nil {
+			setupLog.Error(err, "unable to load TLS configuration from file")
+			return generalExitStatus
+		}
+		platformTLSOpts = opts
 	}
 
 	// Compose the TLS opts applied to all TLS-enabled servers.
 	tlsOpts := composeTLSOpts(platformTLSOpts)
 
-	mgr, err := createManager(cfg, tlsOpts, platformTLSOpts != nil /*isOpenShift*/)
+	mgr, err := createManager(cfg, tlsOpts, platformTLSOpts != nil)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		return generalExitStatus
 	}
 
-	// Create a cancellable context so that controllers (e.g. the TLS
-	// security profile watcher) can trigger a graceful shutdown.
-	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
-	defer cancel()
-
-	// On OpenShift, watch for TLS profile changes on processes that serve
-	// TLS (webhook and metrics) and trigger a graceful shutdown so they
-	// restart with the new configuration.
-	if platformTLSOpts != nil && (environment.IsWebhook() || environment.IsMetricsManager()) {
-		if err := setupTLSProfileWatcher(mgr, cancel); err != nil {
-			setupLog.Error(err, "unable to set up TLS profile watcher")
-			return generalExitStatus
-		}
-	}
+	ctx := ctrl.SetupSignalHandler()
 
 	if err := setupControllersByEnvironment(mgr, tlsOpts); err != nil {
 		return generalExitStatus
@@ -211,32 +212,6 @@ func composeTLSOpts(tlsOpts func(*tls.Config)) func(*tls.Config) {
 		}
 		c.NextProtos = []string{"http/1.1"}
 	}
-}
-
-// setupTLSProfileWatcher watches for platform TLS profile changes and
-// triggers a graceful shutdown so the process restarts with the new config.
-func setupTLSProfileWatcher(mgr manager.Manager, cancel context.CancelFunc) error {
-	// Use a non-cached client for the initial fetch because the manager's
-	// cache is not started yet at this point.
-	apiClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
-	if err != nil {
-		return fmt.Errorf("failed creating client for TLS profile watcher: %w", err)
-	}
-
-	tlsProfileSpec, err := tlspkg.FetchAPIServerTLSProfile(context.Background(), apiClient)
-	if err != nil {
-		return fmt.Errorf("unable to get initial TLS profile for watcher: %w", err)
-	}
-
-	return (&tlspkg.SecurityProfileWatcher{
-		Client:                mgr.GetClient(),
-		InitialTLSProfileSpec: tlsProfileSpec,
-		OnProfileChange: func(ctx context.Context, oldSpec, newSpec configv1.TLSProfileSpec) {
-			setupLog.Info("TLS profile has changed, initiating shutdown to reload",
-				"oldProfile", oldSpec, "newProfile", newSpec)
-			cancel()
-		},
-	}).SetupWithManager(mgr)
 }
 
 // createManager creates and configures the controller manager.

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/spf13/pflag"
 
+	configv1 "github.com/openshift/api/config/v1"
 	openshiftconsolev1 "github.com/openshift/api/console/v1"
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
 
@@ -66,6 +67,7 @@ func init() {
 
 	utilruntime.Must(nmstatev1.AddToScheme(scheme))
 	utilruntime.Must(nmstatev1beta1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 	utilruntime.Must(openshiftoperatorv1.Install(scheme))
 	utilruntime.Must(openshiftconsolev1.Install(scheme))
 	// +kubebuilder:scaffold:scheme

--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -19,6 +19,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,7 +45,11 @@ import (
 
 	"github.com/openshift/cluster-network-operator/pkg/render"
 
+	configv1 "github.com/openshift/api/config/v1"
 	openshiftoperatorv1 "github.com/openshift/api/operator/v1"
+	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/nmstate/kubernetes-nmstate/api/names"
 	"github.com/nmstate/kubernetes-nmstate/api/shared"
@@ -83,6 +89,7 @@ type NMStateReconciler struct {
 // +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;get;watch;update
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=list;get;watch;update;create;patch
 // +kubebuilder:rbac:groups="networking.k8s.io",resources=networkpolicies,verbs="*"
+// +kubebuilder:rbac:groups="config.openshift.io",resources=apiservers,verbs=get;list;watch
 
 func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("nmstate", req.NamespacedName)
@@ -146,11 +153,27 @@ func (r *NMStateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *NMStateReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&nmstatev1.NMState{}).
 		Owns(&appsv1.Deployment{}).
-		Owns(&appsv1.DaemonSet{}).
-		Complete(r)
+		Owns(&appsv1.DaemonSet{})
+
+	// On OpenShift, watch APIServer CR changes to detect TLS profile updates.
+	// This triggers a reconcile that updates the TLS ConfigMap and rolls
+	// webhook/metrics Deployments via a hash annotation.
+	if r.IsOpenShift {
+		builder = builder.WatchesRawSource(source.Kind(
+			mgr.GetCache(),
+			&configv1.APIServer{},
+			handler.TypedEnqueueRequestsFromMapFunc(
+				func(ctx context.Context, obj *configv1.APIServer) []ctrl.Request {
+					return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: "nmstate"}}}
+				},
+			),
+		))
+	}
+
+	return builder.Complete(r)
 }
 
 func (r *NMStateReconciler) applyManifests(instance *nmstatev1.NMState, ctx context.Context) error {
@@ -358,6 +381,23 @@ func (r *NMStateReconciler) applyHandler(ctx context.Context, instance *nmstatev
 	data.Data["LogLevelHandlerCommandArg"] = logLevelHandlerCommandArg
 	data.Data["HandlerReadinessProbeExtraArg"] = handlerReadinessProbeExtraArg
 	data.Data["IsOpenShift"] = r.IsOpenShift
+
+	// On OpenShift, fetch and serialize the TLS profile so handler-deployed
+	// pods can read it from a ConfigMap instead of calling the API server.
+	// A hash annotation on the pod templates triggers a rolling restart
+	// when the TLS profile changes.
+	if r.IsOpenShift {
+		tlsProfileSpec, err := tlspkg.FetchAPIServerTLSProfile(ctx, r.APIClient)
+		if err != nil {
+			return fmt.Errorf("failed fetching TLS profile for ConfigMap: %w", err)
+		}
+		tlsJSON, err := json.Marshal(tlsProfileSpec)
+		if err != nil {
+			return fmt.Errorf("failed serializing TLS profile: %w", err)
+		}
+		data.Data["TLSProfileJSON"] = string(tlsJSON)
+		data.Data["TLSProfileHash"] = fmt.Sprintf("%x", sha256.Sum256(tlsJSON))
+	}
 
 	return r.renderAndApply(ctx, instance, data, "handler", true)
 }

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -27,6 +27,9 @@ spec:
         description: kubernetes-nmstate-metrics dump nmstate metrics
         target.workload.openshift.io/management: |
           {"effect": "PreferredDuringScheduling"}
+{{- if .IsOpenShift }}
+        nmstate.io/tls-profile-hash: "{{ .TLSProfileHash }}"
+{{- end }}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -78,6 +81,8 @@ spec:
               value: "6060"
             - name: METRICS_BIND_ADDRESS
               value: ":8443"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           ports:
           - containerPort: 8443
             name: metrics
@@ -100,10 +105,16 @@ spec:
           - name: metrics-tls
             readOnly: true
             mountPath: /tmp/k8s-metrics-server/serving-certs
+          - name: tls-config
+            readOnly: true
+            mountPath: /etc/nmstate/tls
       volumes:
         - name: metrics-tls
           secret:
             secretName: {{template "handlerPrefix" .}}openshift-nmstate-metrics
+        - name: tls-config
+          configMap:
+            name: {{template "handlerPrefix" .}}nmstate-tls-config
 {{- end }}
 ---
 apiVersion: apps/v1
@@ -131,6 +142,9 @@ spec:
         description: kubernetes-nmstate-webhook resets NNCP status
         target.workload.openshift.io/management: |
           {"effect": "PreferredDuringScheduling"}
+{{- if .IsOpenShift }}
+        nmstate.io/tls-profile-hash: "{{ .TLSProfileHash }}"
+{{- end }}
     spec:
       serviceAccountName: {{template "handlerPrefix" .}}nmstate-handler
       nodeSelector: {{ toYaml .InfraNodeSelector | nindent 8 }}
@@ -180,6 +194,8 @@ spec:
               value: "False"
             - name: PROFILER_PORT
               value: "6060"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           ports:
           - containerPort: 9443
             name: webhook-server
@@ -211,6 +227,11 @@ spec:
           - name: tls-key-pair
             readOnly: true
             mountPath: /tmp/k8s-webhook-server/serving-certs/
+{{- if .IsOpenShift }}
+          - name: tls-config
+            readOnly: true
+            mountPath: /etc/nmstate/tls
+{{- end }}
       volumes:
         - name: tls-key-pair
           secret:
@@ -218,6 +239,11 @@ spec:
             secretName: {{template "handlerPrefix" .}}nmstate-webhook
 {{- else }}
             secretName: {{template "handlerPrefix" .}}openshift-nmstate-webhook
+{{- end }}
+{{- if .IsOpenShift }}
+        - name: tls-config
+          configMap:
+            name: {{template "handlerPrefix" .}}nmstate-tls-config
 {{- end }}
 {{- if not .IsOpenShift }}
 ---
@@ -413,6 +439,8 @@ spec:
               value: "{{ .ProbeConfiguration.DNS.Host }}"
             - name: METRICS_BIND_ADDRESS
               value: "{{ .MetricsConfiguration.BindAddress }}"
+            - name: IS_OPENSHIFT
+              value: "{{ .IsOpenShift }}"
           volumeMounts:
             - name: dbus-socket
               mountPath: /run/dbus/system_bus_socket

--- a/deploy/handler/role.yaml
+++ b/deploy/handler/role.yaml
@@ -149,14 +149,6 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - apiservers
-  verbs:
-  - get
-  - list
-  - watch
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/handler/tls_config.yaml
+++ b/deploy/handler/tls_config.yaml
@@ -1,0 +1,9 @@
+{{- if .IsOpenShift }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{template "handlerPrefix" .}}nmstate-tls-config
+  namespace: {{ .HandlerNamespace }}
+data:
+  profile.json: '{{ .TLSProfileJSON }}'
+{{- end }}

--- a/deploy/operator/role.yaml
+++ b/deploy/operator/role.yaml
@@ -50,6 +50,14 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -20,8 +20,11 @@ package cluster
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"os"
 
+	configv1 "github.com/openshift/api/config/v1"
 	tlspkg "github.com/openshift/controller-runtime-common/pkg/tls"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -34,6 +37,13 @@ var log = logf.Log.WithName("cluster")
 // IsOpenShift returns always true since this is the openshift fork
 func IsOpenShift(kclient client.Client) (bool, error) {
 	return true, nil
+}
+
+// IsOpenShiftFromEnv returns true if the IS_OPENSHIFT environment variable
+// is set to "true". The operator sets this variable on all handler-deployed
+// pods so they can skip the API server discovery call at startup.
+func IsOpenShiftFromEnv() bool {
+	return os.Getenv("IS_OPENSHIFT") == "true"
 }
 
 // FetchOpenShiftTLSOpts detects OpenShift and fetches the TLS profile for
@@ -64,4 +74,28 @@ func FetchOpenShiftTLSOpts(cfg *rest.Config, scheme *runtime.Scheme) (func(*tls.
 	}
 
 	return tlsOpts, nil
+}
+
+// FetchTLSProfileFromFile reads a TLS profile spec from a JSON file (mounted
+// from a ConfigMap) and returns the TLS options function and the raw spec.
+// This avoids calling the API server at startup, which is critical when
+// network connectivity may be temporarily unavailable.
+func FetchTLSProfileFromFile(path string) (func(*tls.Config), configv1.TLSProfileSpec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, configv1.TLSProfileSpec{}, fmt.Errorf("failed reading TLS profile from %s: %w", path, err)
+	}
+
+	var spec configv1.TLSProfileSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, configv1.TLSProfileSpec{}, fmt.Errorf("failed parsing TLS profile from %s: %w", path, err)
+	}
+
+	tlsOpts, unsupportedCiphers := tlspkg.NewTLSConfigFromProfile(spec)
+	if len(unsupportedCiphers) > 0 {
+		log.Info("TLS configuration contains unsupported ciphers that will be ignored",
+			"unsupportedCiphers", unsupportedCiphers)
+	}
+
+	return tlsOpts, spec, nil
 }


### PR DESCRIPTION
The handler binary calls the API server at startup to detect OpenShift and fetch the TLS security profile. When the default network interface is being reconfigured (e.g. bond removal), the API server is temporarily unreachable, causing a 30s timeout, handler crash, and restart loop.

Fix this by:
- Adding IS_OPENSHIFT env var set by the operator on all handler-deployed pods, eliminating the IsOpenShift() API discovery call
- On OpenShift, the operator fetches the TLS profile and writes it to a ConfigMap. Webhook and metrics pods mount it and read from file instead of calling the API server. Kubelet caches ConfigMap volumes locally, so they survive container restarts without API server connectivity.
- The handler DaemonSet skips TLS profile loading entirely since it does not serve platform-specific TLS endpoints
- TLS profile changes are handled entirely by the operator: it watches the APIServer CR, updates the ConfigMap, and rolls webhook/metrics Deployments via a hash annotation on the pod template

<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind enhancement

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
