### PR TITLE
NO-JIRA: Add SKIP_CONSOLE to ignore console-plugin on handler e2e test runs.

### DIFF
--- a/hack/ocp-e2e-tests-handler.sh
+++ b/hack/ocp-e2e-tests-handler.sh
@@ -48,13 +48,21 @@ oc create -f test/e2e/nmstate.yaml
 # First wait for the handler pods to be created
 while ! oc get pods -n ${NAMESPACE} | grep handler; do sleep 1; done
 # Then wait for them to be ready
-while oc get pods -n ${NAMESPACE} | grep "0/1"; do sleep 1; done
+if [ -n "${SKIP_CONSOLE}" ]; then
+    while oc get pods -n ${NAMESPACE} | grep -v console-plugin | grep "0/1"; do sleep 1; done
+else
+    while oc get pods -n ${NAMESPACE} | grep "0/1"; do sleep 1; done
+fi
 # NOTE(bnemec): The test being filtered with "bridged" was re-enabled in 4.8, but seems to be consistently failing on OCP.
 make test-e2e-handler E2E_TEST_ARGS="--skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=4h
 
 # Reconfigure operator to use custom DNS target for the probe. Wait for handlers to be restarted.
 oc apply -f test/e2e/nmstate-custom-dns.yaml
 sleep 10
-while oc get pods -n ${NAMESPACE} | grep "0/1"; do sleep 1; done
+if [ -n "${SKIP_CONSOLE}" ]; then
+    while oc get pods -n ${NAMESPACE} | grep -v console-plugin | grep "0/1"; do sleep 1; done
+else
+    while oc get pods -n ${NAMESPACE} | grep "0/1"; do sleep 1; done
+fi
 FOCUS_TESTS="Dns configuration"
 make test-e2e-handler E2E_TEST_ARGS="--focus=\"${FOCUS_TESTS}\" --skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=4h


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug

 /kind enhancement

**What this PR does / why we need it**:
Sometimes the console plugin won't start (no image in personal repos) or you don't want to run it on local testings. In these cases SKIP_CONSOLE could be set so the wait will ignore what happens with the console-plugin.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
