### PR TITLE
Node selector description fix

### DIFF
--- a/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
+++ b/deploy/crds/nmstate.io_nodenetworkconfigurationpolicies.yaml
@@ -75,8 +75,11 @@ spec:
                 additionalProperties:
                   type: string
                 description: |-
-                  NodeSelector is a selector which must be true for the policy to be applied to the node.
-                  Selector which must match a node's labels for the policy to be scheduled on that node.
+                  NodeSelector is a selector that determines which nodes the policy will be applied to.
+                  It uses simple key-value label matching (equality-based selection only). All specified
+                  labels must match a node's labels for the policy to be scheduled on that node.
+                  Supports a maximum of 256 label selectors. Note: matchLabels and matchExpressions syntax
+                  are not supported; only direct key-value pair matching is available.
                   More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                 maxProperties: 256
                 type: object


### PR DESCRIPTION
This PR updates the NodeSelector field description in the CRD to more accurately reflect its current behavior and limitations.

Previously, the description referenced general Kubernetes node selector semantics and linked to the upstream documentation, which may imply support for advanced selector features such as matchExpressions. However, the current implementation only supports simple equality-based key-value matching.

What’s changed
Clarified that NodeSelector uses simple key-value (equality-based) label matching only
Explicitly stated that all specified labels must match for the policy to be applied to a node
Added a clear note that matchLabels and matchExpressions are not supported

Why this change
The previous description could mislead users into assuming support for full Kubernetes label selector semantics. This update ensures the documentation is aligned with actual functionality, reducing confusion and preventing incorrect configurations.