### PR TITLE
[4.21] Add AllNamespaces OLM install mode support

### DIFF
--- a/hack/ocp-update-bundle-manifests.sh
+++ b/hack/ocp-update-bundle-manifests.sh
@@ -19,6 +19,11 @@ MONITORING_NAMESPACE=${MONITORING_NAMESPACE} \
 VERSION=${VERSION} CHANNELS=${CHANNEL},alpha DEFAULT_CHANNEL=${CHANNEL} \
 BUNDLE_DIR=${BUNDLE_DIR} MANIFEST_BASES_DIR=${MANIFEST_BASES_DIR} make bundle
 
+# Use fieldRef to dynamically resolve namespace at runtime instead of hardcoding it.
+# This is required for AllNamespaces OLM install mode support.
+$(yq4) --inplace eval '(.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name == "HANDLER_NAMESPACE")) |= {"name": .name, "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}}' ${BUNDLE_DIR}/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+$(yq4) --inplace eval '(.spec.install.spec.deployments[].spec.template.spec.containers[].env[] | select(.name == "OPERATOR_NAMESPACE")) |= {"name": .name, "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}}' ${BUNDLE_DIR}/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+
 # add the cluster permissions to use the privileged security context constraint to the nmstate-operator SA in the CSV
 $(yq4) --inplace eval '.spec.install.spec.clusterPermissions[] |= select(.rules[]) |= select(.serviceAccountName == "nmstate-operator").rules += {"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}' ${BUNDLE_DIR}/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
 

--- a/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -52,7 +52,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - nmstate

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -212,11 +212,15 @@ spec:
                       - name: HANDLER_IMAGE_PULL_POLICY
                         value: IfNotPresent
                       - name: HANDLER_NAMESPACE
-                        value: openshift-nmstate
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: MONITORING_NAMESPACE
                         value: openshift-monitoring
                       - name: OPERATOR_NAMESPACE
-                        value: openshift-nmstate
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                       - name: KUBE_RBAC_PROXY_IMAGE
                         value: quay.io/openshift/origin-kube-rbac-proxy:4.21
                     image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.21
@@ -295,7 +299,7 @@ spec:
       type: SingleNamespace
     - supported: false
       type: MultiNamespace
-    - supported: false
+    - supported: true
       type: AllNamespaces
   keywords:
     - nmstate


### PR DESCRIPTION
Cherry-pick of #743 to release-4.21.

Use Downward API for HANDLER_NAMESPACE and OPERATOR_NAMESPACE
instead of hardcoded values, enabling the operator to auto-detect
its namespace at runtime. Enable AllNamespaces install mode while
keeping OwnNamespace and SingleNamespace for backwards compatibility.