### PR TITLE
[release-4.22] NO-JIRA:  openshift: Add workload annotation to console plugin deployment (#1474)

### DIFF
--- a/deploy/openshift/ui-plugin/deployment.yaml
+++ b/deploy/openshift/ui-plugin/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       app: {{ .PluginName }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: |
+          {"effect": "PreferredDuringScheduling"}
       labels:
         app: {{ .PluginName }}
     spec:


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
The console plugin deployment is missing the
target.workload.openshift.io/management annotation required by OpenShift conformance tests. This was added to the operator and handler deployments in 7b54f862c but the console plugin was missed.



(cherry picked from commit 11a1c14a49fbcbb3211dbbd7af9dfdc7319d3ebd)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
