### PR TITLE
OCPBUGS-87239,OCPBUGS-87351: Bump version from 4.22 to 5.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes-nmstate
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/handler/
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 RUN \
     dnf -y update && \

--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/kubernetes-nmstate
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/operator
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/manager /usr/bin/
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/

--- a/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -18,9 +18,9 @@ metadata:
     categories: OpenShift Optional
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
-    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.22
+    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:5.0
     createdAt: "2022-02-21 08:46:16"
-    olm.skipRange: ">=4.3.0 <4.22.0"
+    olm.skipRange: ">=4.3.0 <5.0.0"
     support: Red Hat, Inc.
     repository: https://github.com/openshift/kubernetes-nmstate
   labels:
@@ -28,7 +28,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: kubernetes-nmstate-operator.v4.22.0
+  name: kubernetes-nmstate-operator.v5.0.0
   namespace: openshift-nmstate
 spec:
   apiservicedefinitions: {}
@@ -73,4 +73,4 @@ spec:
   version: 0.0.1
   labels:
     olm-owner-enterprise-app: kubernetes-nmstate-operator
-    olm-status-descriptors: kubernetes-nmstate-operator.v4.22.0
+    olm-status-descriptors: kubernetes-nmstate-operator.v5.0.0

--- a/manifests/kubernetes-nmstate-operator.package.yaml
+++ b/manifests/kubernetes-nmstate-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: kubernetes-nmstate-operator
 channels:
   - name: "stable"
-    currentCSV: kubernetes-nmstate-operator.v4.22.0
+    currentCSV: kubernetes-nmstate-operator.v5.0.0

--- a/manifests/stable/manifests/image-references
+++ b/manifests/stable/manifests/image-references
@@ -5,16 +5,16 @@ spec:
   - name: kubernetes-nmstate-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kubernetes-nmstate-operator:4.22
+      name: quay.io/openshift/origin-kubernetes-nmstate-operator:5.0
   - name: kubernetes-nmstate-handler
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kubernetes-nmstate-handler:4.22
+      name: quay.io/openshift/origin-kubernetes-nmstate-handler:5.0
   - name: nmstate-console-plugin-rhel8
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-nmstate-console-plugin:4.22
+      name: quay.io/openshift/origin-nmstate-console-plugin:5.0
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.22
+      name: quay.io/openshift/origin-kube-rbac-proxy:5.0

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -16,11 +16,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     certified: "false"
-    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.22
+    containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:5.0
     createdAt: "2026-05-14T05:36:09Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
-    olm.skipRange: ">=4.3.0 <4.22.0"
+    olm.skipRange: ">=4.3.0 <5.0.0"
     operatorframework.io/suggested-namespace: openshift-nmstate
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
@@ -43,7 +43,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: kubernetes-nmstate-operator.v4.22.0
+  name: kubernetes-nmstate-operator.v5.0.0
   namespace: openshift-nmstate
 spec:
   apiservicedefinitions: {}
@@ -212,9 +212,9 @@ spec:
                         value: "6060"
                       - name: RUN_OPERATOR
                       - name: HANDLER_IMAGE
-                        value: quay.io/openshift/origin-kubernetes-nmstate-handler:4.22
+                        value: quay.io/openshift/origin-kubernetes-nmstate-handler:5.0
                       - name: PLUGIN_IMAGE
-                        value: quay.io/openshift/origin-nmstate-console-plugin:4.22
+                        value: quay.io/openshift/origin-nmstate-console-plugin:5.0
                       - name: HANDLER_IMAGE_PULL_POLICY
                         value: IfNotPresent
                       - name: HANDLER_NAMESPACE
@@ -228,8 +228,8 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: KUBE_RBAC_PROXY_IMAGE
-                        value: quay.io/openshift/origin-kube-rbac-proxy:4.22
-                    image: quay.io/openshift/origin-kubernetes-nmstate-operator:4.22
+                        value: quay.io/openshift/origin-kube-rbac-proxy:5.0
+                    image: quay.io/openshift/origin-kubernetes-nmstate-operator:5.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       failureThreshold: 3
@@ -313,7 +313,7 @@ spec:
     - NetworkManager
   labels:
     olm-owner-enterprise-app: kubernetes-nmstate-operator
-    olm-status-descriptors: kubernetes-nmstate-operator.v4.22.0
+    olm-status-descriptors: kubernetes-nmstate-operator.v5.0.0
   links:
     - name: Kubernetes Nmstate Operator
       url: https://github.com/nmstate/kubernetes-nmstate
@@ -326,4 +326,4 @@ spec:
   selector:
     matchLabels:
       name: kubernetes-nmstate-operator
-  version: 4.22.0
+  version: 5.0.0


### PR DESCRIPTION
## Summary

Comprehensive version bump from OpenShift 4.22 to 5.0, including golang builder update from 1.25 to 1.26.

This PR supersedes the partial ART consistency PRs:
- #753 (OCPBUGS-87239) — only updated `.ci-operator.yaml` and `build/Dockerfile.operator.openshift`
- #754 (OCPBUGS-87351) — only updated `.ci-operator.yaml` and `build/Dockerfile.openshift`

Both of those PRs were missing all OLM manifest updates, which are required for a proper version bump.

## Changes

### Build Configuration
- `.ci-operator.yaml`: `rhel-9-release-golang-1.25-openshift-4.22` → `rhel-9-release-golang-1.26-openshift-5.0`
- `build/Dockerfile.openshift`: builder and base image tags updated
- `build/Dockerfile.operator.openshift`: builder and base image tags updated

### OLM Manifests
- `manifests/bases/kubernetes-nmstate-operator.clusterserviceversion.yaml`: containerImage, olm.skipRange, name, olm-status-descriptors
- `manifests/kubernetes-nmstate-operator.package.yaml`: currentCSV
- `manifests/stable/manifests/image-references`: all 4 image tags (operator, handler, console-plugin, kube-rbac-proxy)
- `manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml`: containerImage, olm.skipRange, name, HANDLER_IMAGE, PLUGIN_IMAGE, KUBE_RBAC_PROXY_IMAGE, operator image, olm-status-descriptors, version

## Verification

Changes follow the `.claude/commands/bump-version.md` specification for comprehensive version bumps. No version references remain in non-excluded files.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Operator version upgraded to 5.0.0
  * Go runtime updated from 1.25 to 1.26
  * Base images updated to OpenShift 5.0
  * Container image tags updated from 4.22 to 5.0 across all components (operator, handler, console plugin, and RBAC proxy)
  * Build and deployment manifests updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->