### PR TITLE
OCPBUGS-94072: add startup probes and DNS egress to network policies

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -122,6 +122,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: allow-webhook-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-metrics-egress-api-6443
   namespace: {{ .HandlerNamespace }}
 spec:
@@ -133,6 +152,43 @@ spec:
     - ports:
         - protocol: TCP
           port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-dns
+  namespace: {{ .OperatorNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
   policyTypes:
     - Egress
 ---

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -92,15 +92,19 @@ spec:
           - containerPort: 8443
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: metrics
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: metrics
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -192,6 +196,12 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: webhook-server
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
           readinessProbe:
             httpGet:
               path: /readyz
@@ -200,7 +210,6 @@ spec:
               httpHeaders:
               - name: Content-Type
                 value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
@@ -210,7 +219,6 @@ spec:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
## Problem

nmstate-webhook and nmstate-metrics (kube-rbac-proxy sidecar) pods enter CrashLoopBackOff because liveness/readiness probes kill the containers before they finish initializing.

The root cause is a combination of:

1. **Missing DNS egress in network policies**: The default-deny network policies ([OPNET-673](https://redhat.atlassian.net/browse/OPNET-673)) block all egress except TCP 6443 (API server). DNS (UDP/TCP 53) is not allowed. While the in-cluster API client uses `KUBERNETES_SERVICE_HOST` (an IP) directly, kube-rbac-proxy and various Go libraries attempt DNS lookups during startup. With DNS blocked, each lookup hangs for ~5s (Go resolver timeout), compounding startup delay.

2. **No startupProbe**: Without a startupProbe, the liveness probe (`initialDelaySeconds: 10`, `failureThreshold: 3`, `periodSeconds: 10`) gives containers only ~30s to start. On nodes where DNS-blocked initialization causes delays, this window is exceeded and the container is killed.

Reported via customer escalation: [OCPBUGS-94072](https://issues.redhat.com/browse/OCPBUGS-94072)

## Fix

1. **Add `startupProbe`** (TCP socket) to both kube-rbac-proxy and nmstate-webhook containers with `failureThreshold: 18` and `periodSeconds: 10`, giving up to 3 minutes for startup. Once the startupProbe succeeds, regular liveness/readiness probes take over.

2. **Remove `initialDelaySeconds`** from liveness/readiness probes — the startupProbe handles the startup window, making initialDelaySeconds redundant.

3. **Add DNS egress network policies** (UDP/TCP 53) for webhook, metrics, and operator pods to allow DNS resolution during initialization.

## Probe configuration after this change

**kube-rbac-proxy (metrics pod):**
| Probe | Type | Port | initialDelay | period | failureThreshold |
|-------|------|------|-------------|--------|-----------------|
| startupProbe | TCP | 8443 | 10s | 10s | 18 |
| readinessProbe | TCP | 8443 | - | 10s | - |
| livenessProbe | TCP | 8443 | - | 10s | 3 |

**nmstate-webhook:**
| Probe | Type | Port | initialDelay | period | failureThreshold |
|-------|------|------|-------------|--------|-----------------|
| startupProbe | TCP | 9443 | 10s | 10s | 18 |
| readinessProbe | HTTP GET /readyz | 9443 | - | 10s | - |
| livenessProbe | HTTP GET /readyz | 9443 | - | 10s | 3 |

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*