### PR TITLE
OCPBUGS-97951: add startup probes and DNS egress to network policies

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -122,6 +122,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: allow-webhook-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-metrics-egress-api-6443
   namespace: {{ .HandlerNamespace }}
 spec:
@@ -133,6 +152,43 @@ spec:
     - ports:
         - protocol: TCP
           port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-dns
+  namespace: {{ .OperatorNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
   policyTypes:
     - Egress
 ---

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -82,15 +82,19 @@ spec:
           - containerPort: 8443
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: metrics
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: metrics
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -184,6 +188,12 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: webhook-server
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
           readinessProbe:
             httpGet:
               path: /readyz
@@ -192,7 +202,6 @@ spec:
               httpHeaders:
               - name: Content-Type
                 value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
@@ -202,7 +211,6 @@ spec:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
Backport of [openshift/kubernetes-nmstate#759](https://github.com/openshift/kubernetes-nmstate/pull/759) to release-4.22.

See OCPBUGS-97951 / OCPBUGS-94072 for full description and analysis.

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*