### PR TITLE
NO-ISSUE: [4.22] use SSA with ForceOwnership for NMState CR status updates

### DIFF
--- a/controllers/operator/nmstate_controller.go
+++ b/controllers/operator/nmstate_controller.go
@@ -576,7 +576,7 @@ func (r *NMStateReconciler) reconcileStatus(ctx context.Context, instance *nmsta
 	instance.SetManagedFields(nil)
 
 	//nolint:staticcheck // TODO: migrate to SubResource("status").Apply()
-	return r.Client.Status().Patch(ctx, instance, client.Apply, nmstateOperatorFieldOwner)
+	return r.Client.Status().Patch(ctx, instance, client.Apply, nmstateOperatorFieldOwner, client.ForceOwnership)
 }
 
 func (r *NMStateReconciler) setDegradedCondition(
@@ -603,7 +603,19 @@ func (r *NMStateReconciler) setDegradedCondition(
 		reason,
 		message,
 	)
-	return r.Client.Status().Update(ctx, instance)
+
+	// Use SSA with ForceOwnership, consistent with reconcileStatus(), to
+	// prevent field manager conflicts that make the NMState CR unrecoverable.
+	instance.SetManagedFields(nil)
+	//nolint:staticcheck // TODO: migrate to SubResource("status").Apply()
+	if err := r.Client.Status().Patch(ctx, instance, client.Apply, nmstateOperatorFieldOwner, client.ForceOwnership); err != nil {
+		// Callers invoke this helper while already handling another error
+		// and ignore its return value, so log the failure here to keep it
+		// visible for troubleshooting.
+		r.Log.Error(err, "failed to set degraded condition on NMState CR status", "reason", reason)
+		return err
+	}
+	return nil
 }
 
 func (r *NMStateReconciler) renderAndApply(

--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -90,6 +90,40 @@ func (s *applyCapableStatusWriter) Patch(
 	return s.SubResourceWriter.Patch(ctx, obj, patch, opts...)
 }
 
+// statusPatchRecorder records, for every SSA status patch, whether the
+// ForceOwnership option was supplied.
+type statusPatchRecorder struct {
+	forced []bool
+}
+
+// forceOwnershipSpyClient wraps a client to spy on status SSA patch options.
+type forceOwnershipSpyClient struct {
+	client.Client
+	recorder *statusPatchRecorder
+}
+
+func (c *forceOwnershipSpyClient) Status() client.SubResourceWriter {
+	return &forceOwnershipSpyStatusWriter{SubResourceWriter: c.Client.Status(), recorder: c.recorder}
+}
+
+type forceOwnershipSpyStatusWriter struct {
+	client.SubResourceWriter
+	recorder *statusPatchRecorder
+}
+
+func (s *forceOwnershipSpyStatusWriter) Patch(
+	ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+) error {
+	if patch.Type() == types.ApplyPatchType {
+		patchOpts := &client.SubResourcePatchOptions{}
+		for _, opt := range opts {
+			opt.ApplyToSubResourcePatch(patchOpts)
+		}
+		s.recorder.forced = append(s.recorder.forced, patchOpts.Force != nil && *patchOpts.Force)
+	}
+	return s.SubResourceWriter.Patch(ctx, obj, patch, opts...)
+}
+
 var _ = Describe("NMState controller reconcile", func() {
 	var (
 		cl                         client.Client
@@ -188,6 +222,32 @@ var _ = Describe("NMState controller reconcile", func() {
 	AfterEach(func() {
 		err := os.RemoveAll(manifestsDir)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("when writing NMState CR status", func() {
+		var (
+			recorder *statusPatchRecorder
+			nmstate  *nmstatev1.NMState
+		)
+		BeforeEach(func() {
+			recorder = &statusPatchRecorder{}
+			spyClient := &forceOwnershipSpyClient{Client: cl, recorder: recorder}
+			reconciler.Client = spyClient
+			nmstate = newNMState()
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: existingNMStateName}, nmstate)).To(Succeed())
+		})
+		It("reconcileStatus should use SSA with ForceOwnership", func() {
+			Expect(reconciler.reconcileStatus(context.Background(), nmstate)).To(Succeed())
+			Expect(recorder.forced).NotTo(BeEmpty(), "expected at least one SSA status patch")
+			Expect(recorder.forced).NotTo(ContainElement(false), "every status SSA patch must carry ForceOwnership")
+		})
+		It("setDegradedCondition should use SSA with ForceOwnership", func() {
+			Expect(reconciler.setDegradedCondition(
+				context.Background(), nmstate, shared.NmstateInternalError, "test degraded message",
+			)).To(Succeed())
+			Expect(recorder.forced).NotTo(BeEmpty(), "expected at least one SSA status patch")
+			Expect(recorder.forced).NotTo(ContainElement(false), "every status SSA patch must carry ForceOwnership")
+		})
 	})
 
 	Context("when additional CR is created", func() {


### PR DESCRIPTION
Backport of [nmstate/kubernetes-nmstate#1552](https://github.com/nmstate/kubernetes-nmstate/pull/1552) to `release-4.22`.

## Problem

The NMState CR can become permanently stuck in a Degraded state after a transient error because `reconcileStatus()` and `setDegradedCondition()` use inconsistent status update mechanisms and field managers.

## Fix

- Use server-side apply with `client.ForceOwnership` in both status update paths.
- Log failures from the degraded-condition status patch.
- Add unit coverage ensuring every SSA status patch uses `ForceOwnership`.

## Testing

- API unit suites passed.
- Operator unit tests: 32/32 passed.
- `git diff --check` passed.

Related: OCPBUGS-98155

```release-note
Fix NMState CR becoming permanently stuck in Degraded state after transient errors due to SSA field manager conflicts between status update paths.
```

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*
