### PR TITLE
NO-ISSUE: Limit liveness probe to loopback interface to avoid short write errors

### DIFF
--- a/controllers/operator/nmstate_controller_test.go
+++ b/controllers/operator/nmstate_controller_test.go
@@ -487,7 +487,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				ds := &appsv1.DaemonSet{}
 				err := cl.Get(context.Background(), handlerKey, ds)
 				Expect(err).ToNot(HaveOccurred())
-				expectedCommand := "nmstatectl show -vv 2>&1"
+				expectedCommand := "nmstatectl show lo -vv 2>&1"
 				Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(ContainElement(expectedCommand))
 			})
 		})
@@ -515,7 +515,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				ds := &appsv1.DaemonSet{}
 				err := cl.Get(context.Background(), handlerKey, ds)
 				Expect(err).ToNot(HaveOccurred())
-				expectedCommand := "nmstatectl show  2>&1"
+				expectedCommand := "nmstatectl show lo  2>&1"
 				Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(ContainElement(expectedCommand))
 			})
 		})
@@ -542,7 +542,7 @@ var _ = Describe("NMState controller reconcile", func() {
 				ds := &appsv1.DaemonSet{}
 				err := cl.Get(context.Background(), handlerKey, ds)
 				Expect(err).ToNot(HaveOccurred())
-				expectedCommand := "nmstatectl show  2>&1"
+				expectedCommand := "nmstatectl show lo  2>&1"
 				Expect(ds.Spec.Template.Spec.Containers[0].LivenessProbe.Exec.Command).To(ContainElement(expectedCommand))
 			})
 		})

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -437,7 +437,7 @@ spec:
               command:
               - bash
               - -c
-              - "nmstatectl show {{ .HandlerReadinessProbeExtraArg }} 2>&1"
+              - "nmstatectl show lo {{ .HandlerReadinessProbeExtraArg }} 2>&1"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10

--- a/test/e2e/operator/nmstate_install_test.go
+++ b/test/e2e/operator/nmstate_install_test.go
@@ -198,7 +198,7 @@ var _ = Describe("NMState operator", func() {
 						return false
 					}
 
-					return slices.Contains(probe.Exec.Command, "nmstatectl show -vv 2>&1")
+					return slices.Contains(probe.Exec.Command, "nmstatectl show lo -vv 2>&1")
 				}, 60*time.Second, 1*time.Second).Should(BeTrue(), "handler daemonset livenessProbe should use verbose flag")
 			})
 			AfterEach(func() {
@@ -247,10 +247,10 @@ var _ = Describe("NMState operator", func() {
 					}
 
 					for _, cmd := range probe.Exec.Command {
-						if cmd == "nmstatectl show -vv 2>&1" {
+						if cmd == "nmstatectl show lo -vv 2>&1" {
 							return false // Should not have verbose flag in info mode
 						}
-						if cmd == "nmstatectl show  2>&1" {
+						if cmd == "nmstatectl show lo  2>&1" {
 							return true // Should have plain nmstatectl show command
 						}
 					}
@@ -305,7 +305,7 @@ var _ = Describe("NMState operator", func() {
 					}
 
 					for _, cmd := range probe.Exec.Command {
-						if cmd == "nmstatectl show -vv 2>&1" {
+						if cmd == "nmstatectl show lo -vv 2>&1" {
 							return true
 						}
 					}


### PR DESCRIPTION
Manual backport of upstream nmstate/kubernetes-nmstate#1486 (openshift/kubernetes-nmstate commit 1f02e2588) to release-4.22.

The handler liveness probe runs `nmstatectl show` which outputs the full network state (~83KB). Kubernetes exec probes have a 10KB output limit, causing "short write" errors in kubelet logs. Restrict the probe to query only the loopback interface (`nmstatectl show lo`).

Clean cherry-pick, no conflicts. Verified locally: `go vet` on touched packages and probe-focused unit tests in `controllers/operator` pass on this branch.

Fixes: https://issues.redhat.com/browse/OCPBUGS-98474

Assisted-By: Claude Fable 5