### PR TITLE
[4.21] Backport: NNCP reconcile deadlock (23f26ea and d241f93)

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -23,15 +23,18 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +58,7 @@ import (
 	nmstatev1beta1 "github.com/nmstate/kubernetes-nmstate/api/v1beta1"
 	controllers "github.com/nmstate/kubernetes-nmstate/controllers/handler"
 	controllersmetrics "github.com/nmstate/kubernetes-nmstate/controllers/metrics"
+	"github.com/nmstate/kubernetes-nmstate/pkg/enactmentstatus"
 	"github.com/nmstate/kubernetes-nmstate/pkg/environment"
 	"github.com/nmstate/kubernetes-nmstate/pkg/file"
 	nmstatelog "github.com/nmstate/kubernetes-nmstate/pkg/log"
@@ -218,8 +222,17 @@ func setupWebhookEnvironment(mgr manager.Manager) error {
 	return nil
 }
 
-// setupHandlerEnvironment configures the handler controllers and performs health checks
+// setupHandlerEnvironment cleans up unavailableNodeCounts after unexpected restart,
+// configures the handler controllers and performs health checks
 func setupHandlerEnvironment(mgr manager.Manager) error {
+	// Clean stale unavailable counts from node before starting controllers
+	// Prevents deadlock after unexpected cluster reboot where nodes were
+	// processing NNCP and left stale counts in etcd.
+	if err := cleanStaleUnavailableCounts(mgr); err != nil {
+		setupLog.Error(err, "Failed to cleanup stale unavailable counts, continuing anyway")
+		// Don't error this is best-effort (NNCP needs manual restart)
+	}
+
 	if err := setupHandlerControllers(mgr); err != nil {
 		return err
 	}
@@ -238,6 +251,101 @@ func startManager(mgr manager.Manager) int {
 		return generalExitStatus
 	}
 	return 0
+}
+
+// cleanStaleUnavailableCounts cleans up stale unavailable node counts that have been
+// left in NNCP status after unexpected cluster reboots.
+func cleanStaleUnavailableCounts(mgr manager.Manager) error {
+	ctx := context.Background()
+	nodeName := environment.NodeName()
+	setupLog.Info("Cleaning up stale unavailable counts for node", "node", nodeName)
+
+	apiClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return err
+	}
+
+	enactmentList := &nmstatev1beta1.NodeNetworkConfigurationEnactmentList{}
+	nodeLabel := client.MatchingLabels{nmstateapi.EnactmentNodeLabel: nodeName}
+	if err := apiClient.List(ctx, enactmentList, nodeLabel); err != nil {
+		return err
+	}
+
+	// For each enactment that was "Progressing" (interrupted by reboot)
+	for i := range enactmentList.Items {
+		enactment := &enactmentList.Items[i]
+		if enactmentstatus.IsProgressing(&enactment.Status.Conditions) {
+			policyName := enactment.Labels[nmstateapi.EnactmentPolicyLabel]
+			generationKey := strconv.FormatInt(enactment.Status.PolicyGeneration, 10)
+
+			setupLog.Info("detected stale progressing enactment, cleaning up",
+				"enactment", enactment.Name,
+				"policy", policyName,
+				"generation", generationKey)
+
+			// Decrement counter for this policy and generation
+			if err := decrementStaleUnavailableCount(ctx, apiClient, policyName, generationKey); err != nil {
+				setupLog.Error(err, "Failed to decrement stale count", "policy", policyName)
+				// no return to continue with other enactments
+			}
+
+			// Reset retry count for this enactment and generation
+			if err := resetStaleRetryCount(ctx, apiClient, enactment.Name, generationKey); err != nil {
+				setupLog.Error(err, "Failed to reset stale retry count", "enactment", enactment.Name)
+				// no return to continue with other enactments
+			}
+		}
+	}
+
+	setupLog.Info("Finished cleaning up stale unavailable counts", "node", nodeName)
+	return nil
+}
+
+// decrementStaleUnavailableCount decrements the UnavailableNodeCountMap of a specific
+// policy and generation for startup cleanup.
+func decrementStaleUnavailableCount(ctx context.Context, cli client.Client, policyName, generationKey string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: policyName}, policy); err != nil {
+			return err
+		}
+
+		if policy.Status.UnavailableNodeCountMap == nil {
+			return nil // Nothing to clean up
+		}
+
+		if policy.Status.UnavailableNodeCountMap[generationKey] > 0 {
+			policy.Status.UnavailableNodeCountMap[generationKey]--
+			setupLog.Info("Decremented stale unavailable count",
+				"policy", policyName,
+				"generation", generationKey,
+				"newCount", policy.Status.UnavailableNodeCountMap[generationKey])
+			return cli.Status().Update(ctx, policy)
+		}
+
+		return nil
+	})
+}
+
+// resetStaleRetryCount resets the RetryCount for a specific enactment and generation
+// during startup clean to prevent stale retry counts from previous interrupted reconciles.
+func resetStaleRetryCount(ctx context.Context, cli client.Client, enactmentName, generationKey string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		enactment := &nmstatev1beta1.NodeNetworkConfigurationEnactment{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: enactmentName}, enactment); err != nil {
+			return err
+		}
+
+		if enactment.Status.RetryCount == nil || enactment.Status.RetryCount[generationKey] == 0 {
+			return nil
+		}
+
+		enactment.Status.RetryCount[generationKey] = 0
+		setupLog.Info("Reset stale retry count",
+			"enactment", enactmentName,
+			"generation", generationKey)
+		return cli.Status().Update(ctx, enactment)
+	})
 }
 
 // Handler runs as a daemonset and we want that each handler pod will cache/reconcile only resources that belong the node it runs on.

--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -254,7 +255,13 @@ func startManager(mgr manager.Manager) int {
 }
 
 // cleanStaleUnavailableCounts cleans up stale unavailable node counts that have been
-// left in NNCP status after unexpected cluster reboots.
+// left in NNCP status after unexpected handler restarts or cluster reboots.
+//
+// At handler startup, no applies are in progress for this node. Any enactment that
+// is NOT in Available=True state may have a stale UnavailableNodeCountMap entry from
+// a previous interrupted reconcile. We check !IsAvailable rather than IsProgressing
+// because crashes can leave enactments in various non-progressing states (Failing,
+// Pending, empty conditions) that still have stale counts.
 func cleanStaleUnavailableCounts(mgr manager.Manager) error {
 	ctx := context.Background()
 	nodeName := environment.NodeName()
@@ -271,14 +278,17 @@ func cleanStaleUnavailableCounts(mgr manager.Manager) error {
 		return err
 	}
 
-	// For each enactment that was "Progressing" (interrupted by reboot)
+	// For each enactment that is not Available (may have a stale count from an interrupted apply)
 	for i := range enactmentList.Items {
 		enactment := &enactmentList.Items[i]
-		if enactmentstatus.IsProgressing(&enactment.Status.Conditions) {
+		if !enactmentstatus.IsAvailable(&enactment.Status.Conditions) {
 			policyName := enactment.Labels[nmstateapi.EnactmentPolicyLabel]
+			if policyName == "" {
+				continue
+			}
 			generationKey := strconv.FormatInt(enactment.Status.PolicyGeneration, 10)
 
-			setupLog.Info("detected stale progressing enactment, cleaning up",
+			setupLog.Info("detected stale non-available enactment, cleaning up",
 				"enactment", enactment.Name,
 				"policy", policyName,
 				"generation", generationKey)
@@ -307,6 +317,10 @@ func decrementStaleUnavailableCount(ctx context.Context, cli client.Client, poli
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
 		if err := cli.Get(ctx, types.NamespacedName{Name: policyName}, policy); err != nil {
+			if apierrors.IsNotFound(err) {
+				setupLog.Info("Policy not found during stale count cleanup, skipping", "policy", policyName)
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/enactmentstatus/status.go
+++ b/pkg/enactmentstatus/status.go
@@ -72,6 +72,11 @@ func IsProgressing(conditions *nmstate.ConditionList) bool {
 	return false
 }
 
+func IsAvailable(conditions *nmstate.ConditionList) bool {
+	availableCondition := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable)
+	return availableCondition != nil && availableCondition.Status == corev1.ConditionTrue
+}
+
 func IsRetrying(conditions *nmstate.ConditionList) bool {
 	failedCond := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing)
 	progressingCond := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing)

--- a/pkg/enactmentstatus/status_test.go
+++ b/pkg/enactmentstatus/status_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enactmentstatus
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+func conditionList(conditions ...nmstate.Condition) *nmstate.ConditionList {
+	cl := nmstate.ConditionList(conditions)
+	return &cl
+}
+
+func condition(condType nmstate.ConditionType, status corev1.ConditionStatus) nmstate.Condition {
+	return nmstate.Condition{
+		Type:   condType,
+		Status: status,
+	}
+}
+
+var _ = Describe("IsAvailable", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return true when Available is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionTrue),
+		)
+		Expect(IsAvailable(conditions)).To(BeTrue())
+	})
+	It("should return false when Available is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionFalse),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return false when Available is Unknown", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionUnknown),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return false when only other conditions are present", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsProgressing", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+	It("should return true when Progressing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsProgressing(conditions)).To(BeTrue())
+	})
+	It("should return false when Progressing is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+	It("should return false when Progressing is Unknown", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionUnknown),
+		)
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsRetrying", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return true when both Failing and Progressing are True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeTrue())
+	})
+	It("should return false when Failing is True but Progressing is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return false when only Failing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return false when only Progressing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
Before you click the 'Create pull request' make sure that:
- This PR introduces a single feature of fix, just one
- This PR does not leave the main branch broken
- Every commit in this PR has a commit message explaining what do you change,
  why and what is the outcome
- If your change introduces a complex concept or a change to user interaction
  with the project or the application, make sure to document it
If you don't comply with these rules, you waste your energy, time of reviewers
and cause suffering of future generations.
-->

## Summary
  - Backport of nmstate/kubernetes-nmstate#1427 and nmstate/kubernetes-nmstate#1542
  - Fixes NNCP reconcile deadlock after unexpected cluster/handler restart by cleaning up stale unavailable node counts on handler startup
  - Broadens that cleanup to detect all non-available enactments, not just progressing ones, since crashes can leave enactments in various states that still have stale counts

  ## Cherry-picks
  - 23f26ead7 OCPBUGS-74261: NNCP reconcile deadlock after unexpected cluster / handler restart (#1427)
  - d241f9309 Broaden stale count cleanup to detect all non-available enactments, not just progressing (#1542)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
