### PR TITLE
[4.22] Backport: NNCP reconcile deadlock (d241f93)

### DIFF
--- a/cmd/handler/main.go
+++ b/cmd/handler/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -340,7 +341,13 @@ func startManager(mgr manager.Manager, ctx context.Context) int {
 }
 
 // cleanStaleUnavailableCounts cleans up stale unavailable node counts that have been
-// left in NNCP status after unexpected cluster reboots.
+// left in NNCP status after unexpected handler restarts or cluster reboots.
+//
+// At handler startup, no applies are in progress for this node. Any enactment that
+// is NOT in Available=True state may have a stale UnavailableNodeCountMap entry from
+// a previous interrupted reconcile. We check !IsAvailable rather than IsProgressing
+// because crashes can leave enactments in various non-progressing states (Failing,
+// Pending, empty conditions) that still have stale counts.
 func cleanStaleUnavailableCounts(mgr manager.Manager) error {
 	ctx := context.Background()
 	nodeName := environment.NodeName()
@@ -357,14 +364,17 @@ func cleanStaleUnavailableCounts(mgr manager.Manager) error {
 		return err
 	}
 
-	// For each enactment that was "Progressing" (interrupted by reboot)
+	// For each enactment that is not Available (may have a stale count from an interrupted apply)
 	for i := range enactmentList.Items {
 		enactment := &enactmentList.Items[i]
-		if enactmentstatus.IsProgressing(&enactment.Status.Conditions) {
+		if !enactmentstatus.IsAvailable(&enactment.Status.Conditions) {
 			policyName := enactment.Labels[nmstateapi.EnactmentPolicyLabel]
+			if policyName == "" {
+				continue
+			}
 			generationKey := strconv.FormatInt(enactment.Status.PolicyGeneration, 10)
 
-			setupLog.Info("detected stale progressing enactment, cleaning up",
+			setupLog.Info("detected stale non-available enactment, cleaning up",
 				"enactment", enactment.Name,
 				"policy", policyName,
 				"generation", generationKey)
@@ -393,6 +403,10 @@ func decrementStaleUnavailableCount(ctx context.Context, cli client.Client, poli
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		policy := &nmstatev1.NodeNetworkConfigurationPolicy{}
 		if err := cli.Get(ctx, types.NamespacedName{Name: policyName}, policy); err != nil {
+			if apierrors.IsNotFound(err) {
+				setupLog.Info("Policy not found during stale count cleanup, skipping", "policy", policyName)
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/enactmentstatus/status.go
+++ b/pkg/enactmentstatus/status.go
@@ -72,6 +72,11 @@ func IsProgressing(conditions *nmstate.ConditionList) bool {
 	return false
 }
 
+func IsAvailable(conditions *nmstate.ConditionList) bool {
+	availableCondition := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable)
+	return availableCondition != nil && availableCondition.Status == corev1.ConditionTrue
+}
+
 func IsRetrying(conditions *nmstate.ConditionList) bool {
 	failedCond := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionFailing)
 	progressingCond := conditions.Find(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing)

--- a/pkg/enactmentstatus/status_test.go
+++ b/pkg/enactmentstatus/status_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright The Kubernetes NMState Authors.
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enactmentstatus
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+
+	nmstate "github.com/nmstate/kubernetes-nmstate/api/shared"
+)
+
+func conditionList(conditions ...nmstate.Condition) *nmstate.ConditionList {
+	cl := nmstate.ConditionList(conditions)
+	return &cl
+}
+
+func condition(condType nmstate.ConditionType, status corev1.ConditionStatus) nmstate.Condition {
+	return nmstate.Condition{
+		Type:   condType,
+		Status: status,
+	}
+}
+
+var _ = Describe("IsAvailable", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return true when Available is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionTrue),
+		)
+		Expect(IsAvailable(conditions)).To(BeTrue())
+	})
+	It("should return false when Available is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionFalse),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return false when Available is Unknown", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionAvailable, corev1.ConditionUnknown),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+	It("should return false when only other conditions are present", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsAvailable(conditions)).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsProgressing", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+	It("should return true when Progressing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsProgressing(conditions)).To(BeTrue())
+	})
+	It("should return false when Progressing is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+	It("should return false when Progressing is Unknown", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionUnknown),
+		)
+		Expect(IsProgressing(conditions)).To(BeFalse())
+	})
+})
+
+var _ = Describe("IsRetrying", func() {
+	It("should return false for empty conditions", func() {
+		conditions := conditionList()
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return true when both Failing and Progressing are True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeTrue())
+	})
+	It("should return false when Failing is True but Progressing is False", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionFalse),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return false when only Failing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionFailing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+	It("should return false when only Progressing is True", func() {
+		conditions := conditionList(
+			condition(nmstate.NodeNetworkConfigurationEnactmentConditionProgressing, corev1.ConditionTrue),
+		)
+		Expect(IsRetrying(conditions)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## Summary
  - Backport of nmstate/kubernetes-nmstate#1542
  - Broadens stale unavailable count cleanup at handler startup to detect all non-available enactments, not just progressing ones
  - Crashes can leave enactments in various non-progressing states (Failing, Pending, empty conditions) that still have stale counts, causing NNCP deadlocks

  ## Cherry-picks
  - d241f9309 Broaden stale count cleanup to detect all non-available enactments, not just progressing (#1542)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
