### PR TITLE
OCPBUGS-94072: operator: add startupProbe to nmstate-operator deployment

### DIFF
--- a/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -276,12 +276,18 @@ spec:
                   value: quay.io/openshift/origin-kube-rbac-proxy:4.10.0
                 image: quay.io/nmstate/kubernetes-nmstate-operator:latest
                 imagePullPolicy: IfNotPresent
+                startupProbe:
+                  httpGet:
+                    path: /readyz
+                    port: healthprobe
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 18
                 livenessProbe:
                   failureThreshold: 3
                   httpGet:
                     path: /healthz
                     port: healthprobe
-                  initialDelaySeconds: 10
                   periodSeconds: 10
                   successThreshold: 1
                   timeoutSeconds: 1
@@ -294,7 +300,6 @@ spec:
                   httpGet:
                     path: /readyz
                     port: healthprobe
-                  initialDelaySeconds: 10
                   periodSeconds: 10
                   successThreshold: 1
                   timeoutSeconds: 1

--- a/deploy/operator/operator.yaml
+++ b/deploy/operator/operator.yaml
@@ -60,11 +60,17 @@ spec:
             capabilities:
               drop:
               - ALL
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /readyz
               port: healthprobe
             initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthprobe
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -73,7 +79,6 @@ spec:
             httpGet:
               path: /healthz
               port: healthprobe
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1

--- a/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/kubernetes-nmstate-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     categories: OpenShift Optional
     certified: "false"
     containerImage: quay.io/openshift/origin-kubernetes-nmstate-operator:4.21
-    createdAt: "2025-11-25T05:35:50Z"
+    createdAt: "2026-08-12T15:34:39Z"
     description: |
       Kubernetes NMState is a declaritive means of configuring NetworkManager.
     olm.skipRange: ">=4.3.0 <4.21.0"
@@ -230,7 +230,6 @@ spec:
                       httpGet:
                         path: /healthz
                         port: healthprobe
-                      initialDelaySeconds: 10
                       periodSeconds: 10
                       successThreshold: 1
                       timeoutSeconds: 1
@@ -243,7 +242,6 @@ spec:
                       httpGet:
                         path: /readyz
                         port: healthprobe
-                      initialDelaySeconds: 10
                       periodSeconds: 10
                       successThreshold: 1
                       timeoutSeconds: 1
@@ -259,6 +257,13 @@ spec:
                       capabilities:
                         drop:
                           - ALL
+                    startupProbe:
+                      failureThreshold: 18
+                      httpGet:
+                        path: /readyz
+                        port: healthprobe
+                      initialDelaySeconds: 10
+                      periodSeconds: 10
                     terminationMessagePolicy: FallbackToLogsOnError
                 priorityClassName: system-cluster-critical
                 securityContext:


### PR DESCRIPTION
## What this PR does

Adds a `startupProbe` to the `nmstate-operator` container (deploy template + bundle CSV + ART manifests) and removes `initialDelaySeconds` from its readiness/liveness probes — the same pattern PR #759 applied to the webhook and kube-rbac-proxy operand containers.

## Why

The OCPBUGS-94072 fix shipped in 4.20.29 is incomplete: the customer is still down on 4.20.30/4.20.32, now with the **operator pod** in CrashLoopBackOff (900+ liveness kills observed in the must-gather host journals). The operator container gets only ~40s to bind `:8081` (initialDelay 10s, period 10s, failureThreshold 3), while measured startup in the affected environment is 50–75s. The webhook/metrics pods — which did get startupProbes — recover fine in the same environment, proving the pattern works. Because the operator deployment is CSV-managed, OLM reverts any manual probe edits and marks the CSV Failed/NeedsReinstall.

Evidence and full analysis in OCPBUGS-94072.

Upstream: https://github.com/nmstate/kubernetes-nmstate/pull/1569

---
This PR was prepared with AI assistance. Please verify before acting on it.