### PR TITLE
OCPBUGS-94072: netpol: allow DNS egress to openshift-dns on port 5353

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -135,6 +135,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -171,6 +182,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -189,6 +211,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---


### PR DESCRIPTION
## What this PR does

Adds an OpenShift-gated egress rule (UDP/TCP 5353 to `openshift-dns`) to the three `allow-*-egress-dns` NetworkPolicies introduced by #759.

## Why

On OpenShift the `dns-default` service maps port 53 to CoreDNS pods listening on **5353**, and OVN-Kubernetes evaluates egress NetworkPolicy **after** service DNAT. The [port-53](https://redhat.atlassian.net/browse/port-53) `allow-*-egress-dns` rules therefore never match real DNS traffic — DNS from the webhook, metrics and operator pods is silently dropped despite the allow policy. Blocked DNS is the main contributor to the 50–75s startup stall analysed in OCPBUGS-94072 (cluster-wide proxy environment), which combined with tight probe timing produces permanent CrashLoopBackOff.

This adds the documented OpenShift DNS NetworkPolicy pattern: UDP/TCP **5353** towards the `openshift-dns` namespace, gated on the existing `IsOpenShift` render flag. The [port-53](https://redhat.atlassian.net/browse/port-53) rule is kept for vanilla Kubernetes.

Upstream: https://github.com/nmstate/kubernetes-nmstate/pull/1570
Related probe fix: https://github.com/openshift/kubernetes-nmstate/pull/773 https://github.com/openshift/kubernetes-nmstate/pull/774 https://github.com/openshift/kubernetes-nmstate/pull/775

---
This PR was prepared with AI assistance. Please verify before acting on it.