### PR TITLE
OCPBUGS-94072: netpol: DNS egress policies with openshift-dns 5353 (includes missing #759 forward-port)

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -122,6 +122,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: allow-webhook-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-webhook
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: allow-metrics-egress-api-6443
   namespace: {{ .HandlerNamespace }}
 spec:
@@ -133,6 +152,43 @@ spec:
     - ports:
         - protocol: TCP
           port: 6443
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-egress-dns
+  namespace: {{ .HandlerNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate
+      component: kubernetes-nmstate-metrics
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  policyTypes:
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-operator-egress-dns
+  namespace: {{ .OperatorNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes-nmstate-operator
+  egress:
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
   policyTypes:
     - Egress
 ---

--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -135,6 +135,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -171,6 +182,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -189,6 +211,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---

--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -92,15 +92,19 @@ spec:
           - containerPort: 8443
             name: metrics
             protocol: TCP
-          readinessProbe:
+          startupProbe:
             tcpSocket:
               port: metrics
             initialDelaySeconds: 10
             periodSeconds: 10
+            failureThreshold: 18
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: metrics
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1
@@ -192,6 +196,12 @@ spec:
           - containerPort: 9443
             name: webhook-server
             protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: webhook-server
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 18
           readinessProbe:
             httpGet:
               path: /readyz
@@ -200,7 +210,6 @@ spec:
               httpHeaders:
               - name: Content-Type
                 value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
           livenessProbe:
             httpGet:
@@ -210,7 +219,6 @@ spec:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 1
             successThreshold: 1


### PR DESCRIPTION
## What this PR does

**Two commits:**
1. Cherry-pick of 0fd6985f5 (PR #759, "Bug 94072: add startup probes and DNS egress to network policies") — **this branch never received the original OCPBUGS-94072 fix**: no startupProbes on nmstate-webhook/kube-rbac-proxy and no DNS egress policies. Without it, the original bug regresses on upgrade from 4.20.
2. Adds an OpenShift-gated egress rule (UDP/TCP 5353 to `openshift-dns`) to the three `allow-*-egress-dns` NetworkPolicies.

## Why

On OpenShift the `dns-default` service maps port 53 to CoreDNS pods listening on **5353**, and OVN-Kubernetes evaluates egress NetworkPolicy **after** service DNAT. The [port-53](https://redhat.atlassian.net/browse/port-53) `allow-*-egress-dns` rules therefore never match real DNS traffic — DNS from the webhook, metrics and operator pods is silently dropped despite the allow policy. Blocked DNS is the main contributor to the 50–75s startup stall analysed in OCPBUGS-94072 (cluster-wide proxy environment), which combined with tight probe timing produces permanent CrashLoopBackOff.

This adds the documented OpenShift DNS NetworkPolicy pattern: UDP/TCP **5353** towards the `openshift-dns` namespace, gated on the existing `IsOpenShift` render flag. The [port-53](https://redhat.atlassian.net/browse/port-53) rule is kept for vanilla Kubernetes.

Upstream: https://github.com/nmstate/kubernetes-nmstate/pull/1570
Related probe fix: https://github.com/openshift/kubernetes-nmstate/pull/773 https://github.com/openshift/kubernetes-nmstate/pull/774 https://github.com/openshift/kubernetes-nmstate/pull/775

---
This PR was prepared with AI assistance. Please verify before acting on it.