### PR TITLE
Organize openshift-specific annotations for namespace (release-4.22)

### DIFF
--- a/deploy/handler/namespace.yaml
+++ b/deploy/handler/namespace.yaml
@@ -13,4 +13,5 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
 {{- if .IsOpenShift }}
     openshift.io/cluster-monitoring: "true"
+    openshift.io/node-selector: ""
 {{- end }}


### PR DESCRIPTION
Cherry-pick of nmstate/kubernetes-nmstate commit 54282e06825a261f05487b45bca1fc23c84e3699 ("Organize openshift-specific annotations for namespace") to release-4.22.

Most of the original commit was already present on this branch; the net change adds the `openshift.io/node-selector: ""` annotation to the handler namespace inside the OpenShift-only block.

---
This PR was generated using AI. Please verify before acting on it.
Assisted-By: Claude Fable 5