### PR TITLE
OCPBUGS-97952: netpol: allow DNS egress to openshift-dns on port 5353

### DIFF
--- a/deploy/handler/network_policy.yaml
+++ b/deploy/handler/network_policy.yaml
@@ -147,6 +147,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -183,6 +194,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---
@@ -201,6 +223,17 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+{{- if .IsOpenShift }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353
+        - protocol: TCP
+          port: 5353
+{{- end }}
   policyTypes:
     - Egress
 ---


### PR DESCRIPTION
## What this PR does

Adds an OpenShift-gated egress rule (UDP/TCP 5353 to `openshift-dns`) to the three `allow-*-egress-dns` NetworkPolicies.

The release-5.0 branch already contains the startup probes and [port-53](https://redhat.atlassian.net/browse/port-53) DNS egress policies from #759, so this backport matches the release-4.20 change in #776. The equivalent release-4.21 and release-4.22 changes are #777 and #778.

## Why

On OpenShift the `dns-default` service maps port 53 to CoreDNS pods listening on **5353**, and OVN-Kubernetes evaluates egress NetworkPolicy **after** service DNAT. The [port-53](https://redhat.atlassian.net/browse/port-53) `allow-*-egress-dns` rules therefore never match real DNS traffic — DNS from the webhook, metrics, and operator pods is silently dropped despite the allow policy. Blocked DNS is the main contributor to the 50–75s startup stall analyzed in OCPBUGS-94072 on a cluster with a cluster-wide proxy, which combined with tight probe timing produces permanent CrashLoopBackOff.

This adds the documented OpenShift DNS NetworkPolicy pattern: UDP/TCP **5353** toward the `openshift-dns` namespace, gated on the existing `IsOpenShift` render flag. The [port-53](https://redhat.atlassian.net/browse/port-53) rule is kept for vanilla Kubernetes.

Upstream: https://github.com/nmstate/kubernetes-nmstate/pull/1570
Related backports: #776, #777, #778

---
This message was generated using AI. Please verify before acting on it.