### PR TITLE
OPNET-806: Enable PQC by setting DEFAULT:PQ crypto-policy

### DIFF
--- a/build/Dockerfile.openshift
+++ b/build/Dockerfile.openshift
@@ -3,6 +3,14 @@ WORKDIR /go/src/github.com/openshift/kubernetes-nmstate
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/handler/
 
+# Configure the DEFAULT:PQ crypto-policy so ML-KEM is available via OpenSSL.
+# See OPNET-806 / OCPSTRAT-3113. On FIPS clusters the :PQ subpolicy is
+# disabled automatically by the OS, so no special handling is required here.
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9 AS pqc
+RUN dnf install -y --nodocs crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    dnf clean all && rm -rf /var/cache/*
+
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 
 RUN \
@@ -13,6 +21,8 @@ RUN \
         iproute && \
     dnf clean all
 
+# Enable the DEFAULT:PQ crypto-policy (post-quantum cryptography).
+COPY --from=pqc /etc/crypto-policies/ /etc/crypto-policies/
 
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/manager  /usr/bin/
 

--- a/build/Dockerfile.operator.openshift
+++ b/build/Dockerfile.operator.openshift
@@ -3,7 +3,18 @@ WORKDIR /go/src/github.com/openshift/kubernetes-nmstate
 COPY . .
 RUN GO111MODULE=on go build --mod=vendor -o build/_output/bin/manager ./cmd/operator
 
+# Configure the DEFAULT:PQ crypto-policy so ML-KEM is available via OpenSSL.
+# See OPNET-806 / OCPSTRAT-3113. On FIPS clusters the :PQ subpolicy is
+# disabled automatically by the OS, so no special handling is required here.
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9 AS pqc
+RUN dnf install -y --nodocs crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    dnf clean all && rm -rf /var/cache/*
+
 FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+
+# Enable the DEFAULT:PQ crypto-policy (post-quantum cryptography).
+COPY --from=pqc /etc/crypto-policies/ /etc/crypto-policies/
 
 COPY --from=builder /go/src/github.com/openshift/kubernetes-nmstate/build/_output/bin/manager /usr/bin/
 COPY deploy/crds/nmstate.io_nodenetwork*.yaml /bindata/kubernetes-nmstate/crds/


### PR DESCRIPTION
## What

Enable post-quantum cryptography (PQC) in the kubernetes-nmstate **handler** and **operator** product images by activating the `DEFAULT:PQ` OpenSSL crypto-policy, so that ML-KEM becomes available.

This is part of OpenShift's platform-wide PQC strategy (OCP core payload images completed the same change in June 2026).

## How

Both shipped product images (`build/Dockerfile.openshift`, `build/Dockerfile.operator.openshift`) build on the OCP internal base `registry.ci.openshift.org/ocp/5.0:base-rhel9` rather than a UBI image directly, so the base image cannot simply be swapped for `ubi-minimal-pqc` (Option A in the card).

Instead this follows **Option B** and mirrors exactly what the core payload base image does in [openshift/images](https://github.com/openshift/images/blob/master/base/Dockerfile.rhel9): a dedicated stage runs `update-crypto-policies --set DEFAULT:PQ`, and the resulting `/etc/crypto-policies` is copied into the final image.

- The change is transparent to the component — no behavior or API changes, it simply makes ML-KEM available.
- On FIPS clusters the `:PQ` subpolicy is disabled automatically by the OS, so no special handling is required here.
- Only `main` — no backports.

## Testing / Definition of done

The built image reports `DEFAULT:PQ`:

```
$ cat /etc/crypto-policies/state/current
DEFAULT:PQ
```

A CI run confirming the above is the only validation required by the card.

## Jira

Fixes https://issues.redhat.com/browse/OPNET-806

🤖 *This comment was generated by AI on behalf of @mkowalski, who has reviewed it.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-quantum cryptography support to OpenShift images.
  * OpenSSL now uses the `DEFAULT:PQ` crypto-policy where supported.
  * FIPS environments automatically disable the post-quantum subpolicy when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->