### PR TITLE
NO-ISSUE: Limit liveness probe to loopback interface to avoid short write errors

### DIFF
--- a/deploy/handler/operator.yaml
+++ b/deploy/handler/operator.yaml
@@ -445,7 +445,7 @@ spec:
               command:
               - bash
               - -c
-              - "nmstatectl show -vvv 2>&1"
+              - "nmstatectl show lo -vvv 2>&1"
             initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 10


### PR DESCRIPTION
Manual backport of upstream nmstate/kubernetes-nmstate#1486 (openshift/kubernetes-nmstate commit 1f02e2588) to release-4.20.

The handler liveness probe runs `nmstatectl show`, which outputs the full network state. On busy nodes this is large (~83KB) and slow to produce: Kubernetes exec probes have a 10KB output limit (causing "short write" errors in kubelet logs), and the command can exceed the 10s probe timeout, orphaning `nmstatectl` children that are never reaped by the container init — the zombie leak reported in OCPBUGS-98474. Restrict the probe to query only the loopback interface (`nmstatectl show lo`), which is always present, returns quickly, and produces ~685 bytes of output.

Unlike the release-4.22 (#766) and release-4.21 (#767) backports, this is **not** a clean cherry-pick. The upstream commit also depends on a configurable handler log-level feature (`spec.logLevel` + templated probe arg) that does not exist on release-4.20, so its test additions reference symbols absent from this branch. Only the loopback probe restriction is applied here, and the branch's existing `-vvv` verbosity is preserved:

```diff
-              - "nmstatectl show -vvv 2>&1"
+              - "nmstatectl show lo -vvv 2>&1"
```

The change is confined to `deploy/handler/operator.yaml`, which `build/Dockerfile.operator` copies verbatim into the operator bindata (`/bindata/kubernetes-nmstate/handler/handler.yaml`). No generated manifests or unit tests reference the probe command on release-4.20, so no other files need updating.

Companion backports:
- release-4.22: #766
- release-4.21: #767

Fixes: https://issues.redhat.com/browse/OCPBUGS-98474

Assisted-By: claude-opus-4-8
