### PR TITLE
OCPQUAL-43: add cloud-aware handler e2e runner (single-NIC subset)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,9 @@ test-e2e-operator-ocp:
 test-e2e-azure-ocp:
 	./hack/ocp-e2e-tests-azure.sh
 
+test-e2e-handler-cloud-ocp:
+	./hack/ocp-e2e-tests-cloud.sh
+
 cluster-up:
 	./cluster/up.sh
 

--- a/hack/ocp-e2e-tests-azure.sh
+++ b/hack/ocp-e2e-tests-azure.sh
@@ -1,27 +1,9 @@
 #!/bin/bash
 
+# Azure has a single eth0 NIC. This runner is now a thin wrapper around the generic cloud runner
+# (hack/ocp-e2e-tests-cloud.sh), which works on any cloud; pin PRIMARY_NIC=eth0 for Azure.
+
 set -ex
 
-export KUBEVIRT_PROVIDER=external
-export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
-export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
-export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
-export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-3}"
-export NAMESPACE="${HANDLER_NAMESPACE:-nmstate}"
-
-make cluster-sync-operator
-oc create -f test/e2e/nmstate.yaml
-# On first deployment, it can take a while for all of the pods to come up
-# First wait for the handler pods to be created
-while ! oc get pods -n ${NAMESPACE} | grep handler; do sleep 1; done
-# Then wait for them to be ready
-while oc get pods -n ${NAMESPACE} | grep "0/1"; do sleep 1; done
-
-# This is dedicated runner for Azure. The only NIC is eth0 and we use `oc debug node`
-# instead of SSH to access the nodes.
-FOCUS_TESTS="Dns configuration"
-SKIPPED_TESTS="with DHCP"
-export PRIMARY_NIC=eth0
-export ENV_WITH_ONLY_ONE_NIC=True
-export SSH="./hack/ssh-via-kubectl.sh"
-make test-e2e-handler E2E_TEST_ARGS="--focus=\"${FOCUS_TESTS}\" --skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=4h
+export PRIMARY_NIC="${PRIMARY_NIC:-eth0}"
+exec "$(dirname "$0")/ocp-e2e-tests-cloud.sh"

--- a/hack/ocp-e2e-tests-cloud.sh
+++ b/hack/ocp-e2e-tests-cloud.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Generic cloud runner for the kubernetes-nmstate handler e2e suite.
+#
+# Unlike hack/ocp-e2e-tests-handler.sh -- which targets bare-metal dev-scripts and requires
+# ${SHARED_DIR}/packet-conf.sh, a bastion SSH jump host, and dedicated secondary NICs -- this
+# runner works on any IPI cloud cluster (AWS/Azure/GCP), connected or disconnected:
+#
+#   * node access is via `oc debug node` (hack/ssh-via-kubectl.sh), not a bastion;
+#   * it runs in single-NIC mode (cloud VMs have one usable NIC, enslaved to br-ex under
+#     OVN-Kubernetes), so bond/secondary-NIC tests are not attempted;
+#   * the primary NIC name is auto-detected (override with PRIMARY_NIC), since it differs per
+#     cloud (Azure eth0, AWS ens5, GCP ens4);
+#   * it runs the single-NIC / OVN-safe subset (DNS configuration), matching the behaviour of
+#     the previous Azure-only runner.
+#
+# hack/ocp-e2e-tests-azure.sh delegates here with PRIMARY_NIC=eth0.
+
+set -ex
+
+export KUBEVIRT_PROVIDER=external
+export IMAGE_BUILDER="${IMAGE_BUILDER:-podman}"
+export DEV_IMAGE_REGISTRY="${DEV_IMAGE_REGISTRY:-quay.io}"
+export KUBEVIRTCI_RUNTIME="${KUBEVIRTCI_RUNTIME:-podman}"
+export FLAKE_ATTEMPTS="${FLAKE_ATTEMPTS:-3}"
+export NAMESPACE="${HANDLER_NAMESPACE:-nmstate}"
+
+# Deploy the operator (this consumes the operator/handler images -- on a disconnected cluster
+# they are served from the mirror registry) and the NMState CR, then wait for the handler pods.
+make cluster-sync-operator
+oc create -f test/e2e/nmstate.yaml
+# On first deployment, it can take a while for all of the pods to come up.
+# First wait for the handler pods to be created, then wait for them to be ready.
+while ! oc get pods -n "${NAMESPACE}" | grep handler; do sleep 1; done
+while oc get pods -n "${NAMESPACE}" | grep "0/1"; do sleep 1; done
+
+# Determine the physical uplink NIC. Cloud VMs have a single NIC that, under OVN-Kubernetes, is
+# enslaved to br-ex, and its name differs per platform, so auto-detect it unless the caller pins
+# PRIMARY_NIC. The executed subset (see below) does not reconfigure this interface, so this value
+# is used only for read-only assertions; detection is therefore best-effort with a safe fallback.
+function detect_primary_nic() {
+  ( set +e +x
+    local node
+    node="$(oc get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+    [ -z "${node}" ] && exit 0
+    # The single-quoted script below runs on the node via `oc debug`; its variables must expand
+    # remotely, not locally.
+    # shellcheck disable=SC2016
+    oc -n default debug "node/${node}" -- chroot /host bash -c '
+      # Prefer the physical port of br-ex (OVN); else the default-route device; else the first
+      # physical ethernet device.
+      if command -v ovs-vsctl >/dev/null 2>&1 && ovs-vsctl br-exists br-ex 2>/dev/null; then
+        for p in $(ovs-vsctl list-ports br-ex 2>/dev/null); do
+          [ -e "/sys/class/net/${p}/device" ] && { echo "${p}"; exit 0; }
+        done
+      fi
+      dev="$(ip -o route get 1.1.1.1 2>/dev/null | sed -n "s/.* dev \([^ ]*\).*/\1/p" | head -1)"
+      [ -n "${dev}" ] && [ "${dev}" != "br-ex" ] && [ -e "/sys/class/net/${dev}/device" ] && { echo "${dev}"; exit 0; }
+      for d in /sys/class/net/*/device; do
+        n="$(basename "$(dirname "${d}")")"
+        case "${n}" in en*|eth*) echo "${n}"; exit 0;; esac
+      done
+    ' 2>/dev/null | tr -d "\r" | tail -1
+  )
+}
+
+export PRIMARY_NIC="${PRIMARY_NIC:-$(detect_primary_nic)}"
+export PRIMARY_NIC="${PRIMARY_NIC:-eth0}"
+echo "Using PRIMARY_NIC=${PRIMARY_NIC}"
+
+export ENV_WITH_ONLY_ONE_NIC=True
+export SSH="./hack/ssh-via-kubectl.sh"
+
+# Single-NIC / OVN-safe subset: the "Dns configuration" specs. The "with DHCP" contexts
+# reconfigure the uplink NIC (not possible with a single OVN-managed NIC), so they are skipped --
+# the remaining specs configure dns-resolver without touching the uplink.
+FOCUS_TESTS="Dns configuration"
+SKIPPED_TESTS="with DHCP"
+make test-e2e-handler E2E_TEST_ARGS="--focus=\"${FOCUS_TESTS}\" --skip=\"${SKIPPED_TESTS}\" --flake-attempts=${FLAKE_ATTEMPTS}" E2E_TEST_TIMEOUT=4h


### PR DESCRIPTION
## Summary

Phase 1 of [OCPQUAL-43](https://redhat.atlassian.net/browse/OCPQUAL-43): make the handler e2e runnable on **cloud** clusters (AWS/Azure/GCP), connected or disconnected.

The existing entrypoint `hack/ocp-e2e-tests-handler.sh` targets bare-metal dev-scripts — it requires `${SHARED_DIR}/packet-conf.sh`, a bastion SSH jump host, and dedicated secondary NICs — so it fails immediately on cloud clusters:
```
./hack/ocp-e2e-tests-handler.sh: line 28: /tmp/secret/packet-conf.sh: No such file or directory
```

## What changed

- **New `hack/ocp-e2e-tests-cloud.sh`** — a generic cloud runner that:
  - accesses nodes via `oc debug node` (`hack/ssh-via-kubectl.sh`), not a bastion;
  - runs in single-NIC mode (`ENV_WITH_ONLY_ONE_NIC=True`);
  - **auto-detects the primary uplink NIC** (override with `PRIMARY_NIC`), which differs per cloud (Azure `eth0`, AWS `ens5`, GCP `ens4`) — preferring the physical port of `br-ex` under OVN, then the default-route device;
  - runs the single-NIC / OVN-safe subset (`--focus="Dns configuration" --skip="with DHCP"`), matching the previous Azure runner.
- **`hack/ocp-e2e-tests-azure.sh`** now delegates to the generic runner with `PRIMARY_NIC=eth0` — no behaviour change for the existing Azure job.
- **`Makefile`**: new `test-e2e-handler-cloud-ocp` target.

## Scope

**Single-NIC subset only** (this PR). Cloud VMs have one NIC enslaved to `br-ex` under OVN, so bond/bridge-on-secondary-NIC and primary-NIC-destructive tests are not attempted; the executed DNS-config subset configures `dns-resolver` without reconfiguring the uplink. Fuller coverage via attaching a secondary NIC is a possible future follow-up.

## Testing

- `shellcheck` clean on both scripts; `test-e2e-handler-cloud-ocp` dry-run OK; no new whitespace issues.
- Azure delegation preserves the prior behaviour (`PRIMARY_NIC=eth0`, single-NIC, DNS focus).
- End-to-end validation happens via the openshift/release disconnected AWS/Azure/GCP jobs once the Phase-2 wire-up (a `kubernetes-nmstate-e2e-handler-cloud` step) lands and calls `make test-e2e-handler-cloud-ocp`.

Part of [OCPQUAL-36](https://redhat.atlassian.net/browse/OCPQUAL-36) (disconnected custom-image mirroring); this unblocks the `test` phase of those cloud jobs.

---
This PR was generated with AI assistance. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running end-to-end tests on cloud-based OpenShift clusters, including connected and disconnected environments.
  * Added automatic primary network interface detection with optional configuration.
  * Added a dedicated command for running cloud-based OpenShift end-to-end tests.

* **Improvements**
  * Streamlined Azure test execution through the shared cloud test workflow.
  * Focused cloud validation on DNS configuration scenarios while excluding DHCP tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->